### PR TITLE
Improve stability of benchmark test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
   "pytest-homeassistant-custom-component",
   "pytest-timeout",
   "ruff",
+  "snakeviz",
   "tomlkit",
   "ty",
 ]

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import cProfile
 import gc
 import io
 import json
@@ -1745,11 +1746,14 @@ class PhaseTimer:
         self.current_phase: str | None = None
         self._stack: list[tuple[str, float, float]] = []
         self._monitor = resource_monitor
+        self.enabled: bool = True
 
     def _current_rss(self) -> float:
         """Get the current process RSS memory utilization in MB."""
-        if self._monitor is not None:
-            return self._monitor.current_rss_mb
+        if self._monitor is not None and self._monitor.is_alive():
+            sampled_rss_mb = self._monitor.current_rss_mb
+            if sampled_rss_mb > 0.0:
+                return sampled_rss_mb
         try:
             with open("/proc/self/stat", "rb") as f:
                 parts = f.read().decode().split()
@@ -1760,12 +1764,16 @@ class PhaseTimer:
 
     def start(self, name: str) -> None:
         """Start measuring a phase by name."""
+        if not self.enabled:
+            return
         rss = self._current_rss()
         self.current_phase = name
         self._stack.append((name, time.perf_counter(), rss))
 
     def stop(self) -> None:
         """Stop the current active phase timing and record statistics."""
+        if not self.enabled:
+            return
         if not self._stack:
             return
         name, start_time, start_rss = self._stack.pop()
@@ -1781,6 +1789,8 @@ class PhaseTimer:
 
     def record(self, name: str, elapsed: float, rss_delta: float = 0.0) -> None:
         """Directly record performance numbers for a given phase name."""
+        if not self.enabled:
+            return
         self.phases.setdefault(name, []).append(elapsed)
         self.memory_deltas.setdefault(name, []).append(rss_delta)
 
@@ -1798,7 +1808,7 @@ class PhaseTimer:
 class ResourceMonitor(threading.Thread):
     """Monitors CPU, memory (RSS, VmSize, VmPeak), and GC of the current process."""
 
-    def __init__(self, interval: float = 0.02) -> None:
+    def __init__(self, interval: float = 0.1) -> None:
         """Initialize the background resource monitoring thread."""
         super().__init__(daemon=True)
         self.interval: float = interval
@@ -1865,7 +1875,11 @@ class ResourceMonitor(threading.Thread):
         self.stop_event.set()
 
     def snapshot_gc(self) -> None:
-        """Take a snapshot of current garbage collection stats."""
+        """Take a snapshot of current garbage collection stats.
+
+        Note: This method is safe to call even if the monitoring thread has not
+        been started (e.g., when target is 'components').
+        """
         try:
             gc_stats = gc.get_stats()
             self.gc_snapshots.append(
@@ -1886,7 +1900,11 @@ class ResourceMonitor(threading.Thread):
             pass
 
     def get_cpu_metrics(self) -> dict[str, float]:
-        """Compute average and peak CPU utilization percentages."""
+        """Compute average and peak CPU utilization percentages.
+
+        Note: This method returns zeroed metrics safely if the thread has not
+        been started.
+        """
         with self._lock:
             if len(self.cpu_samples) < 2:
                 return {"avg_pct": 0.0, "peak_pct": 0.0}
@@ -1905,7 +1923,11 @@ class ResourceMonitor(threading.Thread):
             }
 
     def get_memory_metrics(self) -> dict[str, float]:
-        """Compute average and peak memory (RSS and Vm) metrics in MB."""
+        """Compute average and peak memory (RSS and Vm) metrics in MB.
+
+        Note: This method returns zeroed metrics safely if the thread has not
+        been started.
+        """
         with self._lock:
             return {
                 "rss_avg_mb": sum(self.rss_samples) / len(self.rss_samples)
@@ -2465,6 +2487,7 @@ def _profile_evaluate(
     for run_idx in range(total_runs):
         is_warmup = run_idx < warmup
         label = f"evaluate_run_{run_idx}"
+        timer.enabled = not is_warmup
 
         if is_warmup:
             print(f"Warmup run {run_idx + 1}/{warmup} ...", flush=True)
@@ -2472,9 +2495,9 @@ def _profile_evaluate(
             print(f"Profiling run {run_idx - warmup + 1}/{iterations} ...", flush=True)
 
         if granularity == "coarse" or is_warmup:
-            timer.start(label)
             gc.collect()
             monitor.snapshot_gc()
+            timer.start(label)
 
             asyncio.run(
                 run_evaluation(
@@ -2488,9 +2511,9 @@ def _profile_evaluate(
             )
             timer.stop()
         elif granularity == "medium":
-            timer.start(label)
             gc.collect()
             monitor.snapshot_gc()
+            timer.start(label)
             with timer.phase("evaluate_total"):
                 asyncio.run(
                     run_evaluation(
@@ -2504,9 +2527,9 @@ def _profile_evaluate(
                 )
             timer.stop()
         else:  # fine
-            timer.start(label)
             gc.collect()
             monitor.snapshot_gc()
+            timer.start(label)
             with timer.phase("evaluate_total"):
                 asyncio.run(
                     run_evaluation(
@@ -2560,6 +2583,7 @@ def _profile_build_index(
         for run_idx in range(total_runs):
             is_warmup = run_idx < warmup
             label = f"build_index_{lang}"
+            timer.enabled = not is_warmup
 
             sources = load_language_intent_sources(lang)
             gc.collect()
@@ -2568,7 +2592,7 @@ def _profile_build_index(
             timer.start(label)
             with timer.phase(f"build_candidates_{lang}"):
                 candidates = build_candidates_from_intent_sources(lang, sources, slots)
-            with timer.phase(f"build_index_{lang}"):
+            with timer.phase(f"build_index_only_{lang}"):
                 build_index(lang, candidates)
             timer.stop()
 
@@ -2638,6 +2662,7 @@ def _profile_rank(
         for run_idx in range(total_runs):
             is_warmup = run_idx < warmup
             label = f"rank_{lang}"
+            timer.enabled = not is_warmup
 
             gc.collect()
             monitor.snapshot_gc()
@@ -2775,6 +2800,7 @@ def _profile_components(
 
     for run_idx in range(total_runs):
         is_warmup = run_idx < warmup
+        timer.enabled = not is_warmup
         for query_raw, query_norm, lang, lit_text in all_queries:
             if is_warmup:
                 _ = normalize_text(query_raw)
@@ -2918,19 +2944,25 @@ def _build_report(
     if per_lang:
         report["per_language"] = per_lang
 
-    cpu_metrics = monitor.get_cpu_metrics()
-    mem_metrics = monitor.get_memory_metrics()
-    report["resource"] = {**cpu_metrics, **mem_metrics}
+    if monitor.cpu_samples and monitor.rss_samples:
+        cpu_metrics = monitor.get_cpu_metrics()
+        mem_metrics = monitor.get_memory_metrics()
+        report["resource"] = {**cpu_metrics, **mem_metrics}
 
     regressions = baseline.compare(
         target, report, max_regression_pct, warn_on_missing=warn_on_missing
     )
     report["regressions"] = regressions
 
+    stability_min_duration_sec = 0.010
     cov_values: list[float] = []
     for _phase_name, phase_data in phase_stats.items():
         e = phase_data.get("elapsed")
-        if isinstance(e, dict) and e.get("cov_pct", 0) > 0:
+        if (
+            isinstance(e, dict)
+            and e.get("cov_pct", 0) > 0
+            and float(e.get("mean", 0.0)) >= stability_min_duration_sec
+        ):
             cov_values.append(float(e["cov_pct"]))
     if cov_values:
         avg_cov = statistics.mean(cov_values)
@@ -2970,10 +3002,11 @@ def _run_profiling(
     print(f"Languages: {', '.join(sorted(datasets.keys()))}")
     print(f"{'=' * 90}")
 
-    monitor = ResourceMonitor(interval=0.02)
+    monitor = ResourceMonitor(interval=0.1)
     timer = PhaseTimer(monitor)
 
-    monitor.start()
+    if target != "components":
+        monitor.start()
     monitor.snapshot_gc()
     gc.collect()
     gc.disable()
@@ -2998,8 +3031,9 @@ def _run_profiling(
     finally:
         gc.enable()
         monitor.snapshot_gc()
-        monitor.stop_monitor()
-        monitor.join(timeout=5.0)
+        if target != "components":
+            monitor.stop_monitor()
+            monitor.join(timeout=5.0)
 
     report = _build_report(
         target,
@@ -3241,6 +3275,29 @@ def _write_profile_all_text(all_reports: dict[str, Any], path: str) -> None:
     while lines and lines[-1] == "":
         lines.pop()
     atomic_write(path, "\n".join(lines) + "\n")
+
+
+def _save_cprofile_metric(
+    pr: cProfile.Profile,
+    profile_dir: Path,
+    sort_key: str,
+    filename: str,
+    action: str,
+    label: str,
+) -> io.StringIO:
+    """Extract, sort, and save cProfile statistics to a text file."""
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).sort_stats(sort_key)
+    if action == "print_stats":
+        ps.print_stats(50)
+    elif action == "print_callers":
+        ps.print_callers(50)
+    elif action == "print_callees":
+        ps.print_callees(50)
+    out_path = profile_dir / filename
+    out_path.write_text(s.getvalue(), encoding="utf-8")
+    print(f"cProfile {label} summary saved to {out_path}")
+    return s
 
 
 # ---------------------------------------------------------------------------
@@ -3607,9 +3664,7 @@ def main() -> None:
             # Optional cProfile dump during rankings profiling
             if args.cprofile:
                 print("\nRunning cProfile snapshot ...", flush=True)
-                import cProfile as cProf
-
-                pr = cProf.Profile()
+                pr = cProfile.Profile()
                 pr.enable()
 
                 _bootstrap_project_imports()
@@ -3633,12 +3688,59 @@ def main() -> None:
                 pr.dump_stats(str(prof_dump))
                 print(f"cProfile dump saved to {prof_dump}")
 
-                s = io.StringIO()
-                ps = pstats.Stats(pr, stream=s).sort_stats("cumulative")
-                ps.print_stats(50)
+                # 1. Cumulative time stats (overall bottlenecks)
+                s_cum = _save_cprofile_metric(
+                    pr,
+                    profile_dir,
+                    "cumulative",
+                    "profile_metrics_cumulative.txt",
+                    "print_stats",
+                    "cumulative",
+                )
+
+                # 2. Internal time stats (tottime) - crucial for micro-optimizations
+                _ = _save_cprofile_metric(
+                    pr,
+                    profile_dir,
+                    "tottime",
+                    "profile_metrics_tottime.txt",
+                    "print_stats",
+                    "internal-time",
+                )
+
+                # 3. Call count stats (ncalls) - find functions called too frequently
+                _ = _save_cprofile_metric(
+                    pr,
+                    profile_dir,
+                    "ncalls",
+                    "profile_metrics_ncalls.txt",
+                    "print_stats",
+                    "call-count",
+                )
+
+                # 4. Callers relationship stats - showing function callers
+                _ = _save_cprofile_metric(
+                    pr,
+                    profile_dir,
+                    "tottime",
+                    "profile_metrics_callers.txt",
+                    "print_callers",
+                    "callers",
+                )
+
+                # 5. Callees relationship stats - showing function callees
+                _ = _save_cprofile_metric(
+                    pr,
+                    profile_dir,
+                    "tottime",
+                    "profile_metrics_callees.txt",
+                    "print_callees",
+                    "callees",
+                )
+
                 print("\nTOP 50 FUNCTIONS BY CUMULATIVE TIME:")
                 print("-" * 80)
-                print(s.getvalue())
+                print(s_cum.getvalue())
 
         except KeyboardInterrupt:
             print("\nPROFILE_INTERRUPTED", flush=True)

--- a/uv.lock
+++ b/uv.lock
@@ -228,14 +228,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
 ]
 
 [[package]]
@@ -262,6 +262,7 @@ dev = [
     { name = "pytest-homeassistant-custom-component" },
     { name = "pytest-timeout" },
     { name = "ruff" },
+    { name = "snakeviz" },
     { name = "tomlkit" },
     { name = "ty" },
 ]
@@ -285,6 +286,7 @@ dev = [
     { name = "pytest-homeassistant-custom-component" },
     { name = "pytest-timeout" },
     { name = "ruff" },
+    { name = "snakeviz" },
     { name = "tomlkit" },
     { name = "ty" },
 ]
@@ -567,30 +569,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.29"
+version = "1.43.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/a6/9c02ff00d08ea87908934351d244e35bb6fb5cbc169e1a14fc5bd80d124b/boto3-1.43.29.tar.gz", hash = "sha256:354006c512cdb87ef8214a095f2ade961c8145734475cd7a7e6b39260ff5494a", size = 113198, upload-time = "2026-06-12T19:32:23.442Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/8a/1d33e395da9319b162046ff7d7e75550756425c2a236d8682b4a1bbdec1c/boto3-1.43.31.tar.gz", hash = "sha256:8165b79c02955affbe4b4e9aa7c560684d0d4d86b4b9de66a37b45eb79fc4b69", size = 113122, upload-time = "2026-06-16T19:45:02.677Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/5c/f12a9978526c7068c873ccf9788161fc6af338c6a025f1354a46134a6e46/boto3-1.43.29-py3-none-any.whl", hash = "sha256:77c27ada27cdbf619a3bbc41fa9e991caef818d3a2988cf92ea722e107d90108", size = 140537, upload-time = "2026-06-12T19:32:21.682Z" },
+    { url = "https://files.pythonhosted.org/packages/13/66/67b54f12fc0c5b2dc6fd0c04ea4cf1e7fc4a9843de680a22070d1fd77901/boto3-1.43.31-py3-none-any.whl", hash = "sha256:69c5521ad864f33d4d53b0e18a3927697f4558210693b1cb4dd97da959d1f7b9", size = 140533, upload-time = "2026-06-16T19:44:59.93Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.29"
+version = "1.43.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/54/df99c5ca5c9ef275e34b87e177782e3ca054fc35f1f462c40fe180936c81/botocore-1.43.29.tar.gz", hash = "sha256:dce39d33b707aa162aa3820975f99d7f8f746d46576169fb42ce4f2b3b56b261", size = 15512384, upload-time = "2026-06-12T19:32:13.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/17/225ae5e7253441ae3beadf26aa12c2f9ce292f386a4877a2ed0bb17d6014/botocore-1.43.31.tar.gz", hash = "sha256:c249625faaa353c5b4004043706a394a4f3bcd3643e242f6b01fff6dc70e988b", size = 15540929, upload-time = "2026-06-16T19:44:47.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/b1/aa410c22355f8f6c4ac2433db6a1c557dd959acf2953ccae4bfc37488119/botocore-1.43.29-py3-none-any.whl", hash = "sha256:5d62f2a03ed279a50207ca2824e009313df15f082b6bb591a095a4f04c7faef3", size = 15194135, upload-time = "2026-06-12T19:32:09.463Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl", hash = "sha256:4c51c63f39515fc1a2b8e3e2c29e452009c988ba55ad489251658fdd3aedad6e", size = 15223619, upload-time = "2026-06-16T19:44:43.116Z" },
 ]
 
 [[package]]
@@ -1085,15 +1087,15 @@ wheels = [
 
 [[package]]
 name = "hassil"
-version = "3.8.0"
+version = "3.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "unicode-rbnf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/35/f4efdf2005f45916e338ade57090d5cb1b017708d9fcca6eaa58c69ca1c5/hassil-3.8.0.tar.gz", hash = "sha256:3ab16e659776576f19a28a0eeabc484a21eeef4d3b1189e6074ec113aad8eeb9", size = 63583, upload-time = "2026-06-12T20:00:43.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/7f/05b74d6a9e4e92b2daa93373f42b02298bb5fbc34bbf06b32172679b7a6c/hassil-3.8.1.tar.gz", hash = "sha256:b8eade174e29cdf2e87e64884511df8e2a2405b59723afd2ecfba5f11f951b63", size = 63894, upload-time = "2026-06-15T20:57:30.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/cd/509db1e122433e419bd6cac655f23c77d44e245b0c76ae8c0b437d48ba07/hassil-3.8.0-py3-none-any.whl", hash = "sha256:c9dfb194f26a6aeaa1072188a8adbc84948774a1e5f06d6c487f1bc66f32c685", size = 53669, upload-time = "2026-06-12T20:00:42.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/56/f5f4845cf98aeb98aa0dd40e9a4747db5142906cd61b57b8554ed1a8fe1f/hassil-3.8.1-py3-none-any.whl", hash = "sha256:9ec2e1e13ad2b9f37d6ad27beb1f878d1c023a100e9a31bd88dd64d615a3ae3b", size = 53758, upload-time = "2026-06-15T20:57:29.334Z" },
 ]
 
 [[package]]
@@ -1575,26 +1577,26 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.4.4"
+version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/13/3d71b3adbf385f7dc7fb6e16d6e25421fd8398b45d8f8410a328bf22bd3f/prek-0.4.4.tar.gz", hash = "sha256:4ec5771153d158a0e4473933b7fd9b51e1b1f57f2df50aeb7560ea6812226dc5", size = 470641, upload-time = "2026-06-04T07:26:07.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/65/23866f43521d31173879aa74bb3a2df50ab7f3f74cdb4eaa31b8f446c7ca/prek-0.4.5.tar.gz", hash = "sha256:2be7bcf839de19a0144ed5a5aadf73bc5899cf6823bb1c58cf1d45ae389c201a", size = 482566, upload-time = "2026-06-15T11:36:48.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/9f/68a577888edf7f2647a652b02899508ccd84e57ce1f79c51a44edfd308d7/prek-0.4.4-py3-none-linux_armv6l.whl", hash = "sha256:23cfd96a25de1c93e3c43c746643b80489e3b2fa49ca9c0ffd6022e51535c900", size = 5550271, upload-time = "2026-06-04T07:26:17.834Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b8/5427a0023116343a8d787b446536a7fddfa5db7eec7713dd05618da2bdfe/prek-0.4.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a427b792c4436f49732b1f6ebccf221fdcc6390c148474280da9c2c6eaabc9c4", size = 5910136, upload-time = "2026-06-04T07:26:20.616Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/4f/d751e90b7e768e472e054cd41cbe502589436ca9c1a13bfe4fa9513f9cde/prek-0.4.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b998038fc92c990e03147eb5b95b0f2c394517f8857ab911aac8e092f1b9b3ab", size = 5470124, upload-time = "2026-06-04T07:26:29.23Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/fe/e73241c5777b6f9b6b95132febbd27f9be9e89912e9e93c0982680593af2/prek-0.4.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:9cebca8c15da4f1d6e3a25e6ae0611425c8596e926222050f2588c390e42df8a", size = 5732725, upload-time = "2026-06-04T07:26:19.133Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/a3/329bd910e7e5d9d0eb5e571f3ba48023213744e78411afb81f5ef8356cab/prek-0.4.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c8742ac26363e74c855df6215a709d5db183204d00ac0f1a722b13aed4da3cd0", size = 5457953, upload-time = "2026-06-04T07:26:23.41Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/f8/d642990513d9707398506bad45d39173d84266231f7d919899f694aefe2c/prek-0.4.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a2b7c8710546a1e894afa7ab022030cd4e21f1ee7ffb301b4360773d22f1f00f", size = 5860556, upload-time = "2026-06-04T07:26:11.692Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/17/a2e29cb278503a8c18612d8a62a15020648dc768e2e94bc4b4d4c9411e07/prek-0.4.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e02bd4d5e05c500e4d9f70f024e30d13aa361dc490724b7f476d2e35542c239f", size = 6652492, upload-time = "2026-06-04T07:26:09.962Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/10/ad3270b18135ee5d1af6f6cf4b0c8601b1cc2cb38d16e835081da820833a/prek-0.4.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f3a25041733de987a47e5a7bace47182a6f0e2ae5f960cb54c1d4630afd2591", size = 6113837, upload-time = "2026-06-04T07:26:24.873Z" },
-    { url = "https://files.pythonhosted.org/packages/59/d9/e8c201b9b41c4561673cea01c630ab604df89d13e952f87dbcb807d32588/prek-0.4.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0b04a0f36d07474f2a9fc5b1ba1197a1b326b2b211f39cd74cf0d4613545f7f4", size = 5729155, upload-time = "2026-06-04T07:26:26.194Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/cd/227b0494fcbc91e8fe15c2a4db9e6dfff95314ef38db3e40e6ea96db249d/prek-0.4.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f032ccbe2d6edc345f81a6d772c18cc169d63c27b5a8292bfe416b352bdfee57", size = 5590775, upload-time = "2026-06-04T07:26:22.038Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/e0/9d750b9cf21ece884afdc15668d0f005a36588fe1b0bb5ff4a8112ab51cb/prek-0.4.4-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:bad3586fcea3e913f0edf2e8f132f97889e03976b7ee3d120fd294ad4e89a5eb", size = 5437864, upload-time = "2026-06-04T07:26:30.673Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/48/e2e5c0299590ad18a253c0ac09508b615baa1b382010c511186572f711d3/prek-0.4.4-py3-none-musllinux_1_1_i686.whl", hash = "sha256:4058638532c6dcbf0076d23b9264cbdd9f0f0e320762e237a6b9e4e4b854a766", size = 5718579, upload-time = "2026-06-04T07:26:27.786Z" },
-    { url = "https://files.pythonhosted.org/packages/54/48/7fb3d4e7f664d1ce8ae35ec553872ffddf9fab4c5081735fdaae610b1e7c/prek-0.4.4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:619bab14071670249777deea0cc0b29d904c4a514cf33b20e583900a544f0399", size = 6231622, upload-time = "2026-06-04T07:26:16.309Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c0/a4ddbf38034afe67cfa97c4bd81c86429ada098e7c323218d9f9fd061566/prek-0.4.4-py3-none-win32.whl", hash = "sha256:143154b329c05b2f9fa3230e604d02d9c4297dd43f96135a8ba166772e8ecd60", size = 5240317, upload-time = "2026-06-04T07:26:08.726Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/8c/fe97b5b095187bb2f93bbe406bccf108c879e5e4c83f165809b0d16ce0fb/prek-0.4.4-py3-none-win_amd64.whl", hash = "sha256:c38c5140ae2ea55ebb02e6ca590a416664ea1af287cdd21f54daeec53a81015a", size = 5626104, upload-time = "2026-06-04T07:26:14.81Z" },
-    { url = "https://files.pythonhosted.org/packages/25/63/3586226d536796e65f8e725b531d6104e55caaa18659bdcb512661629586/prek-0.4.4-py3-none-win_arm64.whl", hash = "sha256:3efa28fb37b9ddbafb7759da8d497f0d36cf02a05816e15d6541f5669d5d2114", size = 5470399, upload-time = "2026-06-04T07:26:13.231Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/cb/a9eedf9a35ca6ec72f12af2b4392d7f757bb24863b7b7af4523f939cf3fa/prek-0.4.5-py3-none-linux_armv6l.whl", hash = "sha256:f7517774c72b001573520dc7111156779fd3e5b4452c11f09ff53c71a067e835", size = 5618105, upload-time = "2026-06-15T11:36:21.998Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a7/c96c06f17db7da0a57be2be4c229aa00b525bca8001c9c765663b339cbb7/prek-0.4.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aca9fa995536036a0171bcf7a4db96dc0a14f480054eda1d7d1c2e7739650993", size = 5972998, upload-time = "2026-06-15T11:36:41.12Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f1/721695355cdaa44be6f091e3a77fb9c72ed60289520f78b2f8c9a7197bdd/prek-0.4.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:66877ff21ae9d548f0f7e56fab8e65f1500a74a810e7749188c3f35a4a1b911b", size = 5525098, upload-time = "2026-06-15T11:36:30.127Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/1b/a334e1bb5361b49adf52b5ac7b6532018940f9f0f253437e8f43c3c1f7f3/prek-0.4.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:50697089a86a78d16f087c1912a2f3bc2bea82319a220fac52cc8e3ec9fc0426", size = 5793732, upload-time = "2026-06-15T11:36:35.745Z" },
+    { url = "https://files.pythonhosted.org/packages/28/8c/aff94d276e91207a87cedff7cfefdd4aca20444137cca77bf53fffebe77a/prek-0.4.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:590427a42a3c1e5064487a0dc91167ae0c8a52168e77f574758ef9b138fcfd61", size = 5521719, upload-time = "2026-06-15T11:36:39.383Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/73/cfb0c5c909442050a8357e26233f7e511ba8e0d2f4b0bdc460065d62beb6/prek-0.4.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fd98b986767dafdb6b4305b563ee5a3a8f13bd3c78b98d708626815ea9f147f", size = 5922623, upload-time = "2026-06-15T11:36:18.063Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ad/ff9d26551ba80d190bd08c6341176a5d56d4e6de9c2ebf077793d4adbb78/prek-0.4.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fccd11613ae92619d1ecda0ab3359ceebeb38898909ec84a8d383733d12158cc", size = 6722071, upload-time = "2026-06-15T11:36:43.086Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/11d1dfd66c919953fe89ae2fdedd4f413ee923883043816d35982177bb75/prek-0.4.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14109d37b33e5529db41a3539d4f8f72d295f6eeddede3964994d898b8cec05c", size = 6176454, upload-time = "2026-06-15T11:36:33.803Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/9749f25c2e0ee5225f812457b888acef301e0ccce64bebcda2ac1d04abee/prek-0.4.5-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:40d262418105b2ede9836593a1927fc927cc8093c432e998640964102196996e", size = 5791133, upload-time = "2026-06-15T11:36:23.891Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/72/5e0344bab1eacf813a5b1b082cb4c6253930096166dad51c1cccee0a4f83/prek-0.4.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a586d14c3b852fdee1c3dcd0b9cb0915db9f9d054334b854fd9470bf68edf129", size = 5658098, upload-time = "2026-06-15T11:36:44.862Z" },
+    { url = "https://files.pythonhosted.org/packages/be/a5/1f406e0362dd0f18ba09a562d50d7c04a70ac05d350b1ab6fba36ca3e9f0/prek-0.4.5-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:a8ed0d28f3e7790e4402a9324c386509066df6e67cc587f7406f9a245b97b7e8", size = 5498634, upload-time = "2026-06-15T11:36:31.828Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/df/b0cbf0fa527330188390b7b6c8d279cd5e509923262d0a6c5cc44bbdf103/prek-0.4.5-py3-none-musllinux_1_1_i686.whl", hash = "sha256:86f76bd3d2ecf6fd9034d75c62ff4c786eb11d0dd0a1f79bbb4343b023e12769", size = 5784840, upload-time = "2026-06-15T11:36:37.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d7/977ee3c622c906677dd94187a00392ce2dd76035486b3a3b1b5a5267dd34/prek-0.4.5-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:e491a1a4641d91d8b03dcce5588397e76d2a5b432c9b0a6c70475972b4512ab4", size = 6300384, upload-time = "2026-06-15T11:36:27.602Z" },
+    { url = "https://files.pythonhosted.org/packages/79/fa/43b1d761381dc1c7eeb8f2235c66e902970d4b2bff2dec0f02836c085769/prek-0.4.5-py3-none-win32.whl", hash = "sha256:7546989b2403c96137bd79d19ebfe21facb87266cefe819db2458c3b9b23f350", size = 5287935, upload-time = "2026-06-15T11:36:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/fe/59b5eb3124f5a4cc255a93857b9ab42402635b273f157e91de23bfa40e8f/prek-0.4.5-py3-none-win_amd64.whl", hash = "sha256:8b2ac9227504371d97338215b344184cb0b31ca94113515a3a90c509c6c5a707", size = 5682560, upload-time = "2026-06-15T11:36:25.865Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0e/589ff0eab9034909b1ec8654ee03483797305fb743b3554ce6140d82da9d/prek-0.4.5-py3-none-win_arm64.whl", hash = "sha256:646a86a1a082dbd99fed96314b1064f5644bb34c1f4037a63547a18e2160fb86", size = 5509019, upload-time = "2026-06-15T11:36:46.595Z" },
 ]
 
 [[package]]
@@ -2332,14 +2334,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.18.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
 ]
 
 [[package]]
@@ -2374,6 +2376,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "snakeviz"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/06/82f56563b16d33c2586ac2615a3034a83a4ff1969b84c8d79339e5d07d73/snakeviz-2.2.2.tar.gz", hash = "sha256:08028c6f8e34a032ff14757a38424770abb8662fb2818985aeea0d9bc13a7d83", size = 182039, upload-time = "2024-11-09T22:03:58.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/f7/83b00cdf4f114f10750a18b64c27dc34636d0ac990ccac98282f5c0fbb43/snakeviz-2.2.2-py3-none-any.whl", hash = "sha256:77e7b9c82f6152edc330040319b97612351cd9b48c706434c535c2df31d10ac5", size = 183477, upload-time = "2024-11-09T22:03:57.049Z" },
 ]
 
 [[package]]
@@ -2483,6 +2497,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Improve stability and observability of benchmark profiling by refining timing control, resource monitoring, and profiling outputs.

Enhancements:
- Add an enable flag to the phase timer to skip timing during warmup runs and avoid recording unstable measurements.
- Guard RSS sampling against a dead resource monitor and relax the sampling interval to reduce monitoring overhead.
- Disable the background resource monitor for component-level profiling where it is not needed.
- Exclude very short phases from stability (CoV) calculations by enforcing a minimum mean duration threshold.
- Rename index-building phase labeling to distinguish index-only work from candidate construction.
- Expand cProfile reporting to generate multiple detailed summaries (cumulative time, internal time, call counts, callers, callees) as separate artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added `snakeviz` to development dependencies.
* **Bug Fixes**
  * Improved benchmarking/profiling correctness by separating warmup timing from measured phases.
  * Refined stability scoring to better reflect meaningful, nontrivial phase results.
  * Enhanced resource metric reporting to be more reliable and conditionally included when data is available.
  * Improved profiling exports by generating clearer cProfile view outputs (when enabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->