### PR TITLE
Harden shutdown lifecycle and bm25 ranking behavior

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,24 +1,17 @@
 name: CI
 
 on:
-  push:
+  push: &ci_trigger
     branches:
       - main
     paths:
       - "**.py"
+      - "**.json"
+      - "**.yaml"
+      - "**.yml"
       - "pyproject.toml"
       - "uv.lock"
-      - ".github/workflows/ci.yaml"
-      - "tools/compatibility_matrix.json"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "**.py"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/ci.yaml"
-      - "tools/compatibility_matrix.json"
+  pull_request: *ci_trigger
   workflow_dispatch:
 
 permissions:

--- a/custom_components/assist_canonicalizer/__init__.py
+++ b/custom_components/assist_canonicalizer/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from functools import partial
 from typing import Any
@@ -64,7 +65,9 @@ async def async_setup_entry(
 
     async_setup_services(hass)
 
-    hass.async_create_task(_async_warmup_pipeline_languages(hass, runtime))
+    runtime.track_warmup_task(
+        hass.async_create_task(_async_warmup_pipeline_languages(hass, runtime))
+    )
 
     return True
 
@@ -76,7 +79,7 @@ async def async_unload_entry(
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if not unload_ok:
         return False
-    _runtime_from_entry(hass, entry).cleanup()
+    await _runtime_from_entry(hass, entry).async_shutdown()
     async_unload_services(hass)
     domain_data: dict[str, Any] = hass.data.get(DOMAIN, {})
     domain_data.pop(entry.entry_id, None)
@@ -131,6 +134,8 @@ def _handle_intent_updates(
     intents_update: Any,
 ) -> None:
     """Update intent sources and trigger background rebuilds for active languages."""
+    if runtime.closed:
+        return
     active_languages = list(runtime.indexes)
     runtime.update_intent_sources(intents_update)
     for language in active_languages:
@@ -143,6 +148,8 @@ def _debounced_registry_rebuild(
     now: Any = None,
 ) -> None:
     """Refresh registry slot values and rebuild active indexes."""
+    if runtime.closed:
+        return
     runtime.rebuild_timer_cancel = None
     active_languages = list(runtime.indexes)
     _refresh_registry_slot_values(hass, runtime)
@@ -157,6 +164,8 @@ def _schedule_registry_refresh(
     event: Any = None,
 ) -> None:
     """Schedule a debounced refresh after a registry update."""
+    if runtime.closed:
+        return
     if runtime.rebuild_timer_cancel is not None:
         runtime.rebuild_timer_cancel()
         runtime.rebuild_timer_cancel = None
@@ -203,6 +212,8 @@ async def _warmup_single_language(
     language: str,
 ) -> None:
     """Try to load an index from store, falling back to a rebuild. Never raises."""
+    if runtime.closed:
+        return
     try:
         index = runtime.get_index(language)
         if index is not None:
@@ -224,6 +235,8 @@ async def _async_warmup_pipeline_languages(
     runtime: CanonicalizerRuntime,
 ) -> None:
     """Discover configured pipeline languages and warm every index in the background."""
+    if runtime.closed:
+        return
     languages = _discover_pipeline_languages(hass)
     if not languages:
         try:
@@ -231,5 +244,10 @@ async def _async_warmup_pipeline_languages(
         except Exception:
             return
 
-    for language in languages:
-        hass.async_create_task(_warmup_single_language(hass, runtime, language))
+    async with asyncio.TaskGroup() as task_group:
+        for language in languages:
+            if runtime.closed:
+                return
+            # The setup task tracked by the runtime owns this TaskGroup; the
+            # TaskGroup, in turn, cancels and drains its language children.
+            task_group.create_task(_warmup_single_language(hass, runtime, language))

--- a/custom_components/assist_canonicalizer/bm25.py
+++ b/custom_components/assist_canonicalizer/bm25.py
@@ -199,6 +199,23 @@ class BM25Index:
                 raw_scores[document_index] += precomputed_score
         return raw_scores
 
+    def raw_scores_sparse(self, query_tokens: tuple[str, ...]) -> dict[int, float]:
+        """Return positive unnormalized BM25 scores keyed by touched document index."""
+        if self._average_length == 0:
+            return {}
+        raw_scores: dict[int, float] = {}
+        seen_tokens: set[str] = set()
+        for token in query_tokens:
+            if token in seen_tokens:
+                continue
+            seen_tokens.add(token)
+            postings = self._postings.get(token)
+            if postings is None:
+                continue
+            for document_index, precomputed_score in postings:
+                raw_scores[document_index] = raw_scores.get(document_index, 0.0) + precomputed_score
+        return raw_scores
+
     def score_custom_documents(
         self,
         query: str,

--- a/custom_components/assist_canonicalizer/ranking.py
+++ b/custom_components/assist_canonicalizer/ranking.py
@@ -689,6 +689,19 @@ def _rank_prefilter_keys(
     ]
 
 
+def _rank_prefilter_keys_with_sparse_bm25(
+    char_scores: Sequence[float],
+    raw_bm25_scores: Mapping[int, float],
+    bm25_inv_max: float,
+) -> list[float]:
+    """Return dense-equivalent keys without allocating a dense BM25 score array."""
+    keys = [-CHAR_NGRAM_WEIGHT * char_score for char_score in char_scores]
+    for index, raw_score in raw_bm25_scores.items():
+        normalized_score = raw_score * bm25_inv_max
+        keys[index] -= BM25_WEIGHT * normalized_score
+    return keys
+
+
 def _rank_prefilter_limit(
     candidate_count: int,
     max_candidates: int = DEFAULT_MAX_CANDIDATES,
@@ -705,6 +718,74 @@ def _top_prefilter_indices(
 ) -> list[int]:
     """Return candidate indices selected by the prefilter heap."""
     return nsmallest(prefilter_limit, range(len(prefilter_keys)), key=prefilter_keys.__getitem__)
+
+
+@dataclass(frozen=True, slots=True)
+class _Bm25Scoring:
+    """BM25 values and accessors for one ranking query.
+
+    Static indexes retain only positive raw scores, while dynamic candidates are
+    scored against a reference index and require a dense score sequence. The
+    accessors keep those representations out of the main ranking flow.
+    """
+
+    index: BM25Index
+    max_raw_score: float
+    dense_scores: Sequence[float] | None = None
+    sparse_raw_scores: Mapping[int, float] | None = None
+    sparse_inv_max: float = 0.0
+
+    def prefilter_keys(self, char_scores: Sequence[float]) -> list[float]:
+        """Return prefilter keys using this query's BM25 representation."""
+        if self.sparse_raw_scores is not None:
+            return _rank_prefilter_keys_with_sparse_bm25(
+                char_scores,
+                self.sparse_raw_scores,
+                self.sparse_inv_max,
+            )
+        return _rank_prefilter_keys(char_scores, self.dense_scores or ())
+
+    def score_at(self, index: int) -> float:
+        """Return the normalized BM25 score for one candidate."""
+        if self.sparse_raw_scores is not None:
+            return self.sparse_raw_scores.get(index, 0.0) * self.sparse_inv_max
+        return 0.0 if self.dense_scores is None else self.dense_scores[index]
+
+
+def _prepare_bm25_scoring(
+    candidates: Sequence[Candidate],
+    query_tokens: tuple[str, ...],
+    bm25_index: BM25Index | None,
+    reference_bm25_index: BM25Index | None,
+) -> _Bm25Scoring:
+    """Build query BM25 state for static or reference-index candidate ranking."""
+    if reference_bm25_index is not None:
+        dense_scores = reference_bm25_index.score_custom_documents_tokens(query_tokens, candidates)
+        max_index = max(range(len(dense_scores)), key=dense_scores.__getitem__, default=0)
+        max_raw_score = 0.0
+        if dense_scores[max_index] > 0.0:
+            max_raw_score = reference_bm25_index.raw_score_tokens(
+                candidates[max_index].normalized_tokens,
+                query_tokens,
+            )
+        return _Bm25Scoring(
+            index=reference_bm25_index,
+            max_raw_score=max_raw_score,
+            dense_scores=dense_scores,
+        )
+
+    index = bm25_index or BM25Index.from_normalized_texts(
+        tuple(candidate.normalized_text for candidate in candidates)
+    )
+    sparse_raw_scores = index.raw_scores_sparse(query_tokens) if query_tokens else {}
+    max_raw_score = max(sparse_raw_scores.values(), default=0.0)
+    sparse_inv_max = 1.0 / max_raw_score if max_raw_score > 0.0 else 0.0
+    return _Bm25Scoring(
+        index=index,
+        max_raw_score=max_raw_score,
+        sparse_raw_scores=sparse_raw_scores,
+        sparse_inv_max=sparse_inv_max,
+    )
 
 
 def _query_slot_tokens_from_index(
@@ -1535,6 +1616,9 @@ def rank_candidates(
     Candidate text containing wildcard placeholders is rehydrated from
     *query* before scoring so that real free-text values contribute to
     the semantic match instead of placeholder tokens.
+    A supplied ``bm25_index`` must have been built from ``candidates`` in the
+    same order. ``reference_bm25_index`` deliberately uses a separate corpus
+    and scores the supplied candidates through its dense path instead.
     ``intent_context`` accepts HassIL-style context mappings and is normalized
     by ``utils.normalize_intent_context``.
     """
@@ -1551,6 +1635,12 @@ def rank_candidates(
         raise ValueError("candidate_char_index length must match candidates")
     if candidate_slot_tokens is not None and len(candidate_slot_tokens) != len(candidates):
         raise ValueError("candidate_slot_tokens length must match candidates")
+    if (
+        reference_bm25_index is None
+        and bm25_index is not None
+        and bm25_index.size != len(candidates)
+    ):
+        raise ValueError("bm25_index length must match candidates")
 
     _rehydrated_cache: dict[int, tuple[str, dict[str, str]]] = {}
 
@@ -1569,8 +1659,7 @@ def rank_candidates(
     if positional_literal_tokens is None:
         all_tokens: set[str] = set()
         for candidate in candidates:
-            literal_text = candidate.metadata.get("literal_text")
-            if literal_text:
+            if literal_text := candidate.metadata.get("literal_text"):
                 for variant in literal_token_variants(literal_text):
                     all_tokens.update(variant)
         positional_literal_tokens = frozenset(all_tokens)
@@ -1586,43 +1675,20 @@ def rank_candidates(
     query_numbers = _query_numeric_values(query_tokens)
     intent_score_cache: dict[tuple[frozenset[str], ...], float] = {}
 
-    max_raw_score = 0.0
-    if reference_bm25_index is not None:
-        bm25_scores = reference_bm25_index.score_custom_documents_tokens(
-            query_tokens_tuple, candidates
-        )
-        max_idx = max(range(len(bm25_scores)), key=bm25_scores.__getitem__, default=0)
-        if bm25_scores[max_idx] > 0.0:
-            max_cand = candidates[max_idx]
-            max_raw_score = reference_bm25_index.raw_score_tokens(
-                max_cand.normalized_tokens, query_tokens_tuple
-            )
-    else:
-        if bm25_index is None:
-            # Fallback: rebuild the BM25 index on the fly. This occurs during dynamic candidate
-            # matching passes where a pre-warmed reference BM25 index is absent due to safety
-            # capping of combinatorial expansions. While this introduces a performance trade-off,
-            # it is necessary to ensure correct lexical scoring of all candidate templates.
-            bm25_index = BM25Index.from_normalized_texts(
-                tuple(candidate.normalized_text for candidate in candidates)
-            )
-        doc_count = len(candidates)
-        if not query_tokens_tuple or not doc_count:
-            bm25_scores = (0.0,) * doc_count
-        else:
-            raw_scores = bm25_index.raw_scores(query_tokens_tuple)
-            max_raw_score = max(raw_scores, default=0.0)
-            bm25_scores = _normalized_bm25_scores_from_raw(raw_scores, doc_count)
-
-    _bm25_ref = reference_bm25_index or bm25_index
+    bm25_scoring = _prepare_bm25_scoring(
+        candidates,
+        query_tokens_tuple,
+        bm25_index,
+        reference_bm25_index,
+    )
     if candidate_char_index is None:
         candidate_char_index = CharNGramIndex.from_grams(
             tuple(char_ngrams_normalized(candidate.normalized_text) for candidate in candidates)
         )
     query_grams = char_ngrams_normalized(query_normalized)
     char_scores = candidate_char_index.score(query_grams)
+    prefilter_keys = bm25_scoring.prefilter_keys(char_scores)
 
-    prefilter_keys = _rank_prefilter_keys(char_scores, bm25_scores)
     prefilter_limit = _rank_prefilter_limit(
         len(candidates), max_candidates, rapidfuzz_prefilter_candidates
     )
@@ -1684,8 +1750,8 @@ def rank_candidates(
         query_slot_tokens=query_slot_tokens,
         query_has_number=query_has_number,
         query_numbers=query_numbers,
-        bm25_ref=_bm25_ref,
-        max_raw_score=max_raw_score,
+        bm25_ref=bm25_scoring.index,
+        max_raw_score=bm25_scoring.max_raw_score,
         positional_lookup=positional_lookup,
         positional_literal_tokens=positional_literal_tokens,
         non_entity_tokens=non_entity_tokens,
@@ -1700,7 +1766,7 @@ def rank_candidates(
     )
     for idx in top_indices:
         candidate = candidates[idx]
-        bm25_score = bm25_scores[idx]
+        bm25_score = bm25_scoring.score_at(idx)
         char_score = char_scores[idx]
         item = _score_single_candidate(
             idx,
@@ -2021,6 +2087,8 @@ def evaluate_confidence_gates(
     if competing_candidate is None:
         return top_candidate, None
     if _is_exact_lexical_match(top_candidate):
+        # Exact canonical text is delegated back to HassIL with live request
+        # context; candidate intent/slot metadata is not executed here.
         return top_candidate, None
     if _is_turn_on_off_same_slot_tie(top_candidate, competing_candidate):
         return top_candidate, None

--- a/custom_components/assist_canonicalizer/runtime.py
+++ b/custom_components/assist_canonicalizer/runtime.py
@@ -7,7 +7,7 @@ import contextlib
 import hashlib
 import inspect
 import logging
-from collections.abc import Callable, Mapping, Sequence, Set
+from collections.abc import Awaitable, Callable, Mapping, Sequence, Set
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -69,6 +69,13 @@ _INDEX_MANIFEST_VERSION = 1
 _MAX_REBUILD_ATTEMPTS = 5
 
 
+def _new_set_event() -> asyncio.Event:
+    """Return an asyncio event initialized in the set state."""
+    event = asyncio.Event()
+    event.set()
+    return event
+
+
 @dataclass(frozen=True, slots=True)
 class IndexBuildSnapshot:
     """Immutable inputs and fingerprint for one candidate index build."""
@@ -81,7 +88,12 @@ class IndexBuildSnapshot:
 
 @dataclass(slots=True)
 class CanonicalizerRuntime:
-    """Mutable runtime state shared by the integration entry and agent."""
+    """Mutable runtime state shared by the integration entry and agent.
+
+    Lifecycle invariant: shutdown closes work admission before it cancels tasks.
+    Methods that start or publish work must reject a closed runtime, and methods
+    that span an await must recheck the relevant generation before publishing.
+    """
 
     indexes: dict[str, CanonicalIndex] = field(default_factory=dict)
     diagnostics: CanonicalizerDiagnostics = field(default_factory=CanonicalizerDiagnostics)
@@ -98,18 +110,33 @@ class CanonicalizerRuntime:
     rebuild_tasks: dict[str, tuple[int, asyncio.Task[CanonicalIndex | None]]] = field(
         default_factory=dict
     )
+    warmup_tasks: set[asyncio.Task[Any]] = field(default_factory=set, repr=False)
     _logged_rebuilds: set[tuple[str, int]] = field(default_factory=set, repr=False)
     index_generation: int = 0
     source_generation: int = 0
     rebuild_timer_cancel: Callable[[], None] | None = None
     _storage_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+    _active_index_loads: int = field(default=0, init=False, repr=False)
+    _index_loads_drained: asyncio.Event = field(
+        default_factory=_new_set_event,
+        init=False,
+        repr=False,
+    )
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    @property
+    def closed(self) -> bool:
+        """Return whether this runtime is shutting down or fully closed."""
+        return self._closed
 
     def get_index(self, language: str) -> CanonicalIndex | None:
         """Return the cached index for a language."""
-        return self.indexes.get(normalize_language(language))
+        return None if self._closed else self.indexes.get(normalize_language(language))
 
     def set_index(self, index: CanonicalIndex) -> None:
         """Store a language-specific index."""
+        if self._closed:
+            return
         self.indexes[normalize_language(index.language)] = index
         self.update_diagnostics(
             candidate_count=index.candidate_count,
@@ -125,6 +152,8 @@ class CanonicalizerRuntime:
         raise_on_error: bool = False,
     ) -> CanonicalIndex | None:
         """Rebuild one language index once while concurrent callers await it."""
+        if self._closed:
+            return None
         language = normalize_language(language)
         generation = self.index_generation
         task_state = self.rebuild_tasks.get(language)
@@ -137,6 +166,8 @@ class CanonicalizerRuntime:
             task = None
 
         if task is None:
+            if self._closed:
+                return None
             self._logged_rebuilds.discard((language, generation))
             task = hass.async_create_task(
                 _run_rebuild(
@@ -173,19 +204,43 @@ class CanonicalizerRuntime:
 
     async def async_load_index_from_store(self, hass: Any, language: str) -> CanonicalIndex | None:
         """Load an index only when its persisted source fingerprint is current."""
+        if not self._start_index_load():
+            return None
+        try:
+            return await self._async_load_index_from_store(hass, language)
+        finally:
+            self._finish_index_load()
+
+    async def _async_load_index_from_store(
+        self,
+        hass: Any,
+        language: str,
+    ) -> CanonicalIndex | None:
+        """Load one persisted index while the public operation tracks its lifetime."""
         language = normalize_language(language)
         generation = self.index_generation
         source_generation = self.source_generation
         build_inputs = self._capture_build_inputs()
-        snapshot = await hass.async_add_executor_job(
+        snapshot = await _async_add_executor_job_drained(
+            hass,
             _create_build_snapshot_and_register_wildcards,
             language,
             *build_inputs,
         )
-        if self.index_generation != generation or self.source_generation != source_generation:
+        if (
+            self._closed
+            or self.index_generation != generation
+            or self.source_generation != source_generation
+        ):
             return None
 
         async with self._storage_lock:
+            if (
+                self._closed
+                or self.index_generation != generation
+                or self.source_generation != source_generation
+            ):
+                return None
             manifest = await self._async_load_store_manifest(hass)
             if manifest is None:
                 return None
@@ -194,7 +249,7 @@ class CanonicalizerRuntime:
                 return None
             store = _index_store(hass, language)
             try:
-                data = await store.async_load()
+                data = await _async_await_drained(store.async_load())
             except Exception:
                 return None
 
@@ -204,7 +259,7 @@ class CanonicalizerRuntime:
                 fingerprint=snapshot.fingerprint,
                 cache_epoch=cache_epoch,
             ):
-                await store.async_remove()
+                await _async_await_drained(store.async_remove())
                 persisted_languages.discard(language)
                 await self._async_save_store_manifest(
                     hass,
@@ -214,7 +269,7 @@ class CanonicalizerRuntime:
                 return None
             candidates = _deserialize_candidates(data)
             if candidates is None or len(candidates) != data["candidate_count"]:
-                await store.async_remove()
+                await _async_await_drained(store.async_remove())
                 persisted_languages.discard(language)
                 await self._async_save_store_manifest(
                     hass,
@@ -223,8 +278,12 @@ class CanonicalizerRuntime:
                 )
                 return None
 
-        index = await hass.async_add_executor_job(build_index, language, candidates)
-        if self.index_generation != generation or self.source_generation != source_generation:
+        index = await _async_add_executor_job_drained(hass, build_index, language, candidates)
+        if (
+            self._closed
+            or self.index_generation != generation
+            or self.source_generation != source_generation
+        ):
             return None
         self.language_intent_sources[language] = snapshot.intent_sources
         self.set_index(index)
@@ -240,6 +299,8 @@ class CanonicalizerRuntime:
         expected_source_generation: int | None = None,
     ) -> bool:
         """Save an index with the source fingerprint that produced it."""
+        if self._closed:
+            return False
         language = normalize_language(index.language)
         candidates_data = [_serialize_candidate(candidate) for candidate in index.candidates]
         data = {
@@ -269,19 +330,26 @@ class CanonicalizerRuntime:
                 return False
 
             data["cache_epoch"] = cache_epoch
-            await _index_store(hass, language).async_save(data)
+            await _async_await_drained(_index_store(hass, language).async_save(data))
+            if not self._storage_generation_matches(
+                expected_index_generation,
+                expected_source_generation,
+            ):
+                return False
             persisted_languages.add(language)
             await self._async_save_store_manifest(hass, cache_epoch, persisted_languages)
         return True
 
     async def async_clear_index(self, hass: Any, language: str | None = None) -> None:
         """Clear memory and persisted indexes for one language or every language."""
+        if self._closed:
+            return
         normalized_language = normalize_language(language) if language is not None else None
         async with self._storage_lock:
             self.clear_index(normalized_language)
             manifest = await self._async_load_store_manifest(hass)
             if normalized_language is not None:
-                await _index_store(hass, normalized_language).async_remove()
+                await _async_await_drained(_index_store(hass, normalized_language).async_remove())
                 if manifest is not None:
                     cache_epoch, persisted_languages = manifest
                     persisted_languages.discard(normalized_language)
@@ -295,7 +363,7 @@ class CanonicalizerRuntime:
             persisted_languages = manifest[1] if manifest is not None else set()
             await self._async_save_store_manifest(hass, uuid4().hex, set())
             for persisted_language in persisted_languages:
-                await _index_store(hass, persisted_language).async_remove()
+                await _async_await_drained(_index_store(hass, persisted_language).async_remove())
 
     def rank_with_dynamic_candidates(
         self,
@@ -314,6 +382,8 @@ class CanonicalizerRuntime:
         ``intent_context`` is forwarded as the HassIL-style mapping consumed by
         indexed and dynamic ranking paths.
         """
+        if self._closed:
+            return ()
         language = normalize_language(language)
         ranked = index.rank(
             query,
@@ -414,11 +484,15 @@ class CanonicalizerRuntime:
 
     def configure_config_path(self, config_path: Callable[..., str]) -> None:
         """Configure Home Assistant config path access for custom sentences."""
+        if self._closed:
+            return
         self.config_path = config_path
         self._invalidate_source_dependent_indexes(clear_sources=True)
 
     def update_registry_slot_values(self, slot_values: Mapping[str, tuple[str, ...]]) -> None:
         """Update cached registry metadata used for candidate expansion."""
+        if self._closed:
+            return
         updated_values = {key: tuple(values) for key, values in slot_values.items()}
         if updated_values == self.registry_slot_values:
             return
@@ -429,6 +503,8 @@ class CanonicalizerRuntime:
 
     def update_intent_sources(self, intents_update: Mapping[Any, Mapping[str, Any]]) -> None:
         """Update cached Home Assistant conversation intent sources."""
+        if self._closed:
+            return
         updated_sources = {
             _source_key(source): source_config for source, source_config in intents_update.items()
         }
@@ -454,6 +530,8 @@ class CanonicalizerRuntime:
 
     def _intent_sources_for_query(self, language: str) -> dict[str, Mapping[str, Any]]:
         """Return cached intent sources for query-time candidate expansion."""
+        if self._closed:
+            return {}
         language = normalize_language(language)
         cached = self.language_intent_sources.get(language)
         return cached if cached is not None else self._all_intent_sources(language)
@@ -462,6 +540,8 @@ class CanonicalizerRuntime:
         self, language: str
     ) -> tuple[DynamicRegistryIntent, ...]:
         """Return compiled query-independent registry templates for a language."""
+        if self._closed:
+            return ()
         language = normalize_language(language)
         cached = self.dynamic_registry_intents.get(language)
         if cached is not None:
@@ -498,6 +578,8 @@ class CanonicalizerRuntime:
 
     def _all_intent_sources(self, language: str) -> dict[str, Mapping[str, Any]]:
         """Return built-in, custom, and subscribed intent sources."""
+        if self._closed:
+            return {}
         language = normalize_language(language)
         sources = load_language_intent_sources(language, config_path=self.config_path)
         sources.update(self.intent_sources)
@@ -534,16 +616,36 @@ class CanonicalizerRuntime:
     ) -> bool:
         """Return whether a pending store write still belongs to current inputs."""
         return (
-            expected_index_generation is None or self.index_generation == expected_index_generation
-        ) and (
-            expected_source_generation is None
-            or self.source_generation == expected_source_generation
+            not self._closed
+            and (
+                expected_index_generation is None
+                or self.index_generation == expected_index_generation
+            )
+            and (
+                expected_source_generation is None
+                or self.source_generation == expected_source_generation
+            )
         )
+
+    def _start_index_load(self) -> bool:
+        """Register an index load unless runtime shutdown has started."""
+        if self._closed:
+            return False
+        if self._active_index_loads == 0:
+            self._index_loads_drained.clear()
+        self._active_index_loads += 1
+        return True
+
+    def _finish_index_load(self) -> None:
+        """Release one index load and signal when every load has drained."""
+        self._active_index_loads -= 1
+        if self._active_index_loads == 0:
+            self._index_loads_drained.set()
 
     async def _async_load_store_manifest(self, hass: Any) -> tuple[str, set[str]] | None:
         """Load the cache epoch and known persisted language keys."""
         try:
-            data = await _manifest_store(hass).async_load()
+            data = await _async_await_drained(_manifest_store(hass).async_load())
         except Exception:
             return None
         if not isinstance(data, dict):
@@ -565,16 +667,42 @@ class CanonicalizerRuntime:
         languages: set[str],
     ) -> None:
         """Persist the cache epoch and known language store keys."""
-        await _manifest_store(hass).async_save(
-            {
-                "cache_epoch": cache_epoch,
-                "languages": sorted(languages),
-            }
+        await _async_await_drained(
+            _manifest_store(hass).async_save(
+                {
+                    "cache_epoch": cache_epoch,
+                    "languages": sorted(languages),
+                }
+            )
         )
 
     def add_cleanup_callback(self, callback: Callable[[], None]) -> None:
         """Remember a cleanup callback for unload."""
+        if self._closed:
+            callback()
+            return
         self.cleanup_callbacks.append(callback)
+
+    def track_warmup_task(self, task: Any) -> None:
+        """Track a warmup task so shutdown can cancel and drain it."""
+        if not isinstance(task, asyncio.Task):
+            return
+        if self._closed:
+            task.cancel()
+            return
+        self.warmup_tasks.add(task)
+        task.add_done_callback(lambda done_task: self.warmup_tasks.discard(done_task))
+
+    async def async_shutdown(self) -> None:
+        """Cancel runtime-owned work, wait for storage, and clear caches."""
+        tasks = self._begin_shutdown()
+        current_task = _current_task_or_none()
+        if await_tasks := tuple(task for task in tasks if task is not current_task):
+            await asyncio.gather(*await_tasks, return_exceptions=True)
+        await self._index_loads_drained.wait()
+        async with self._storage_lock:
+            pass
+        self._clear_runtime_state_and_caches()
 
     def cleanup(self) -> None:
         """Run registered cleanup callbacks and purge global module-level caches.
@@ -588,6 +716,15 @@ class CanonicalizerRuntime:
         Ordering: timers and callbacks are torn down first so that no in-flight work
         can observe partially cleared cache state.
         """
+        self._begin_shutdown()
+        self._clear_runtime_state_and_caches()
+
+    def _begin_shutdown(self) -> tuple[asyncio.Task[Any], ...]:
+        """Start shutdown synchronously and return runtime-owned tasks to drain."""
+        if not self._closed:
+            self._closed = True
+            self.index_generation += 1
+            self.source_generation += 1
         if self.rebuild_timer_cancel is not None:
             self.rebuild_timer_cancel()
             self.rebuild_timer_cancel = None
@@ -595,6 +732,29 @@ class CanonicalizerRuntime:
         self.cleanup_callbacks.clear()
         for callback in callbacks:
             callback()
+        tasks: set[asyncio.Task[Any]] = set(self.warmup_tasks)
+        tasks.update(task for _generation, task in self.rebuild_tasks.values())
+        self.warmup_tasks.clear()
+        self.rebuild_tasks.clear()
+        self._logged_rebuilds.clear()
+        current_task = _current_task_or_none()
+        for task in tasks:
+            if task is not current_task and not task.done():
+                task.cancel()
+        return tuple(tasks)
+
+    def _clear_runtime_state_and_caches(self) -> None:
+        """Clear runtime-owned collections and shared module-level caches."""
+        self.indexes.clear()
+        self.intent_sources.clear()
+        self.language_intent_sources.clear()
+        self.registry_slot_values.clear()
+        self.registry_slot_index = RegistrySlotIndex({})
+        self.registry_slot_indexes.clear()
+        self.dynamic_registry_intents.clear()
+        self.rebuild_tasks.clear()
+        self.warmup_tasks.clear()
+        self.update_diagnostics(candidate_count=0, dynamic_candidate_count=0)
         clear_normalization_caches()
         clear_bm25_caches()
         clear_rehydration_caches()
@@ -654,15 +814,24 @@ async def _run_rebuild(
     """Build from a stable source generation and persist the matching fingerprint."""
     try:
         for _ in range(_MAX_REBUILD_ATTEMPTS):
+            if runtime.closed:
+                return None
             source_generation = runtime.source_generation
             build_inputs = runtime._capture_build_inputs()
-            snapshot = await hass.async_add_executor_job(
+            snapshot = await _async_add_executor_job_drained(
+                hass,
                 _create_build_snapshot_and_register_wildcards,
                 language,
                 *build_inputs,
             )
-            index = await hass.async_add_executor_job(_build_index_from_snapshot, snapshot)
-            if runtime.index_generation != generation:
+            if runtime.closed:
+                return None
+            index = await _async_add_executor_job_drained(
+                hass,
+                _build_index_from_snapshot,
+                snapshot,
+            )
+            if runtime.closed or runtime.index_generation != generation:
                 return None
             if runtime.source_generation != source_generation:
                 continue
@@ -674,11 +843,13 @@ async def _run_rebuild(
                 expected_index_generation=generation,
                 expected_source_generation=source_generation,
             )
-            if runtime.index_generation != generation:
+            if runtime.closed or runtime.index_generation != generation:
                 return None
             if runtime.source_generation != source_generation or not saved:
                 continue
 
+            if runtime.closed:
+                return None
             runtime.language_intent_sources[language] = snapshot.intent_sources
             runtime.set_index(index)
             return index
@@ -735,6 +906,53 @@ def _build_index_from_snapshot(snapshot: IndexBuildSnapshot) -> CanonicalIndex:
         snapshot.registry_slot_values,
     )
     return build_index(snapshot.language, candidates)
+
+
+def _current_task_or_none() -> asyncio.Task[Any] | None:
+    """Return the current asyncio task when called inside a running loop."""
+    try:
+        return asyncio.current_task()
+    except RuntimeError:
+        return None
+
+
+async def _async_add_executor_job_drained(hass: Any, func: Callable[..., Any], *args: Any) -> Any:
+    """Run teardown-critical executor work before honoring cancellation.
+
+    Use only for runtime-owned work that must finish before shutdown releases a
+    storage or lifecycle barrier. Do not use it for request-scoped work that is
+    safe to abandon, because cancellation waits for the executor job to finish.
+    """
+    return await _async_await_drained(hass.async_add_executor_job(func, *args))
+
+
+async def _async_await_drained[T](awaitable: Awaitable[T]) -> T:
+    """Await work to completion before propagating cancellation to the caller.
+
+    Shielding means cancellation cannot stop executor-backed storage or index
+    work. During shutdown, keep awaiting that work so its caller cannot release
+    a lifecycle barrier while the underlying operation can still mutate state.
+    The awaitable must therefore be safe to complete after cancellation.
+
+    Catching one cancellation permits the next await to block normally. The
+    loop retries only when another cancellation is delivered, and must retain
+    that behavior so shutdown still drains the underlying work before raising.
+    """
+    job = asyncio.ensure_future(awaitable)
+    try:
+        return await asyncio.shield(job)
+    except asyncio.CancelledError:
+        while not job.done():
+            try:
+                await asyncio.shield(job)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+        if not job.cancelled():
+            with contextlib.suppress(Exception):
+                job.result()
+        raise
 
 
 def _canonical_fingerprint_value(value: Any) -> Any:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "prettier": "^3.9.4",
+        "prettier": "^3.9.5",
         "prettier-plugin-toml": "^2.0.6"
       }
     },
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "prettier": "^3.9.4",
+    "prettier": "^3.9.5",
     "prettier-plugin-toml": "^2.0.6"
   },
   "prettier": {

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -93,6 +93,43 @@ def test_bm25_score_custom_documents_deduplicates_query_tokens() -> None:
     assert res_repeated == res_single
 
 
+@pytest.mark.parametrize(
+    ("documents", "query_tokens"),
+    [
+        ((), ("hello",)),
+        ((BM25Document(text="", tokens=()),), ("hello",)),
+        (
+            (
+                BM25Document(text="alpha beta", tokens=("alpha", "beta")),
+                BM25Document(text="beta gamma", tokens=("beta", "gamma")),
+                BM25Document(text="alpha alpha", tokens=("alpha", "alpha")),
+            ),
+            ("alpha", "alpha", "missing"),
+        ),
+        (
+            (
+                BM25Document(text="đèn phòng khách", tokens=("đèn", "phòng", "khách")),
+                BM25Document(text="den phong khach", tokens=("den", "phong", "khach")),
+                BM25Document(text="kitchen-light", tokens=("kitchen", "light")),
+            ),
+            ("đèn", "khách", "light"),
+        ),
+    ],
+)
+def test_bm25_raw_scores_sparse_matches_dense(
+    documents: tuple[BM25Document, ...],
+    query_tokens: tuple[str, ...],
+) -> None:
+    """Verify sparse BM25 raw scores are dense-equivalent for touched documents."""
+    index = BM25Index(documents)
+
+    dense = index.raw_scores(query_tokens)
+    sparse = index.raw_scores_sparse(query_tokens)
+
+    assert {idx for idx, score in enumerate(dense) if score > 0.0} == set(sparse)
+    assert tuple(sparse.get(idx, 0.0) for idx in range(len(dense))) == tuple(dense)
+
+
 def test_bm25_score_custom_documents_with_candidates_and_cache() -> None:
     """Verify score_custom_documents accepts Candidate-like objects and uses the cache."""
     index = BM25Index.from_texts(["Hello World", "Testing BM25"])

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.components.conversation.const import HOME_ASSISTANT_AGENT
 from homeassistant.components.conversation.models import ConversationInput
 from homeassistant.core import Context
 
@@ -27,7 +28,7 @@ from custom_components.assist_canonicalizer.conversation import (
     AssistCanonicalizerConversationEntity,
     async_setup_entry,
 )
-from custom_components.assist_canonicalizer.indexer import build_index
+from custom_components.assist_canonicalizer.indexer import CanonicalIndex, build_index
 from custom_components.assist_canonicalizer.ranking import RankedCandidate, ScoreBreakdown
 from custom_components.assist_canonicalizer.runtime import CanonicalizerRuntime
 
@@ -440,6 +441,115 @@ async def test_runtime_ranking_receives_satellite_area_context() -> None:
     assert rank.call_args.kwargs["intent_context"] == {
         "area": {"value": "Living Room", "text": "Living Room"}
     }
+
+
+@pytest.mark.asyncio
+async def test_exact_collision_delegates_text_to_hassil_with_original_context() -> None:
+    """Delegate exact same-text collisions to HassIL without executing candidate metadata."""
+    first = Candidate(
+        text="all fan on",
+        intent_name="HassGetState",
+        language="en",
+        metadata={"slots": '{"domain":"fan","state":"on"}'},
+    )
+    second = Candidate(
+        text="all fan on",
+        intent_name="HassTurnOn",
+        language="en",
+        metadata={"slots": '{"domain":"fan"}'},
+    )
+
+    for ordered_candidates in ((first, second), (second, first)):
+        entry = MagicMock()
+        entry.options = {"min_confidence": 0.60, "min_margin": 0.99}
+        entry.entry_id = "test_entry"
+        runtime = CanonicalizerRuntime()
+        runtime.indexes["en"] = CanonicalIndex(language="en", candidates=ordered_candidates)
+        entity = AssistCanonicalizerConversationEntity(entry, runtime)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda target, *args: target(*args))
+        entity.hass = hass
+        context = Context()
+        user_input = MockConversationInput("all fan on", "en", conversation_id="conv-exact")
+        user_input.context = context
+        user_input.device_id = "device-1"
+        user_input.satellite_id = "assist_satellite.kitchen"
+        user_input.extra_system_prompt = "stay local"
+        hassil_result = MagicMock(name="hassil_result")
+        hassil_result.response.error_code = None
+
+        with (
+            patch.object(
+                entity,
+                "_async_try_assist_pipeline_shortcut",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "custom_components.assist_canonicalizer.conversation.conversation.async_converse",
+                AsyncMock(return_value=hassil_result),
+            ) as converse,
+        ):
+            result = await entity._async_process_with_runtime(user_input)
+
+        assert result is hassil_result
+        converse.assert_awaited_once_with(
+            hass,
+            "all fan on",
+            "conv-exact",
+            context,
+            language="en",
+            agent_id=HOME_ASSISTANT_AGENT,
+            device_id="device-1",
+            satellite_id="assist_satellite.kitchen",
+            extra_system_prompt="stay local",
+        )
+
+
+@pytest.mark.asyncio
+async def test_exact_collision_hassil_rejection_falls_back_to_raw_text() -> None:
+    """Continue through validation failure and raw fallback when HassIL rejects exact text."""
+    entry = MagicMock()
+    entry.options = {"min_confidence": 0.60, "min_margin": 0.99}
+    entry.entry_id = "test_entry"
+    runtime = CanonicalizerRuntime()
+    runtime.indexes["en"] = CanonicalIndex(
+        language="en",
+        candidates=(
+            Candidate(text="all fans off", intent_name="HassGetState", language="en"),
+            Candidate(text="all fans off", intent_name="HassTurnOff", language="en"),
+        ),
+    )
+    entity = AssistCanonicalizerConversationEntity(entry, runtime)
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda target, *args: target(*args))
+    entity.hass = hass
+    user_input = MockConversationInput("all fans off", "en")
+    validation_error = MagicMock()
+    validation_error.response.error_code = "no_intent_match"
+
+    with (
+        patch.object(
+            entity,
+            "_async_try_assist_pipeline_shortcut",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            entity,
+            "_delegate_text",
+            AsyncMock(side_effect=[validation_error, validation_error, "raw_result"]),
+        ) as delegate,
+    ):
+        result = await entity._async_process_with_runtime(user_input)
+
+    assert result == "raw_result"
+    assert delegate.await_args_list[0].args == ("all fans off", user_input)
+    assert delegate.await_args_list[0].kwargs == {"primary": True}
+    assert delegate.await_args_list[1].args == ("all fans off", user_input)
+    assert delegate.await_args_list[1].kwargs == {"primary": True}
+    assert delegate.await_args_list[2].args == ("all fans off", user_input)
+    assert delegate.await_args_list[2].kwargs == {"primary": False}
+    assert runtime.diagnostics.last_fallback_reason == FallbackReason.VALIDATION_FAILED
 
 
 def test_area_from_user_input_falls_back_to_original_device_area() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Tests for Assist Canonicalizer integration entry points."""
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -364,12 +365,18 @@ async def test_warmup_single_language_normalizes_input(
 
 
 @pytest.mark.asyncio
-async def test_warmup_pipeline_languages_spawns_tasks() -> None:
-    """Spawn one warmup task per discovered pipeline language."""
+async def test_warmup_pipeline_languages_awaits_child_warmups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Await one warmup child per discovered pipeline language."""
     hass = MagicMock()
     hass.config.language = "en"
-    hass.async_create_task = MagicMock()
     runtime = CanonicalizerRuntime()
+    warmup = AsyncMock()
+    monkeypatch.setattr(
+        "custom_components.assist_canonicalizer._warmup_single_language",
+        warmup,
+    )
 
     pipelines = [MagicMock(language="en"), MagicMock(language="vi")]
     mock_get_pipelines = MagicMock(return_value=pipelines)
@@ -380,30 +387,67 @@ async def test_warmup_pipeline_languages_spawns_tasks() -> None:
     ):
         await _async_warmup_pipeline_languages(hass, runtime)
 
-        assert hass.async_create_task.call_count == 2
-
-        # Close captured coroutines to avoid RuntimeWarning
-        for call_args in hass.async_create_task.call_args_list:
-            call_args[0][0].close()
+    assert warmup.await_count == 2
+    assert {call.args[2] for call in warmup.await_args_list} == {"en", "vi"}
 
 
 @pytest.mark.asyncio
-async def test_warmup_pipeline_languages_fallback_to_default() -> None:
+async def test_shutdown_cancels_task_group_warmup_children(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tracked parent warmup cancellation is propagated to TaskGroup children."""
+    hass = MagicMock()
+    hass.config.language = "en"
+    runtime = CanonicalizerRuntime()
+    child_started = asyncio.Event()
+    child_cancelled = asyncio.Event()
+
+    async def pending_warmup(*_args: Any) -> None:
+        """Wait until the parent TaskGroup propagates cancellation."""
+        child_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            child_cancelled.set()
+            raise
+
+    monkeypatch.setattr(
+        "custom_components.assist_canonicalizer._warmup_single_language",
+        pending_warmup,
+    )
+    with patch.object(
+        custom_components.assist_canonicalizer,
+        "async_get_pipelines",
+        MagicMock(return_value=[MagicMock(language="en")]),
+    ):
+        warmup_task = asyncio.create_task(_async_warmup_pipeline_languages(hass, runtime))
+        runtime.track_warmup_task(warmup_task)
+        await child_started.wait()
+        await runtime.async_shutdown()
+
+    assert warmup_task.cancelled()
+    assert child_cancelled.is_set()
+    assert runtime.warmup_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_warmup_pipeline_languages_fallback_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Fall back to hass.config.language when discovery returns empty."""
     hass = MagicMock()
     hass.config.language = "de"
-    hass.async_create_task = MagicMock()
     runtime = CanonicalizerRuntime()
+    warmup = AsyncMock()
+    monkeypatch.setattr(
+        "custom_components.assist_canonicalizer._warmup_single_language",
+        warmup,
+    )
 
     with patch.object(custom_components.assist_canonicalizer, "async_get_pipelines", None):
         await _async_warmup_pipeline_languages(hass, runtime)
 
-        hass.async_create_task.assert_called_once()
-        created_task_arg = hass.async_create_task.call_args[0][0]
-        assert created_task_arg is not None
-
-        # Close captured coroutine to avoid RuntimeWarning
-        created_task_arg.close()
+    warmup.assert_awaited_once_with(hass, runtime, "de")
 
 
 @pytest.mark.asyncio

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -7,6 +7,7 @@ import orjson
 import pytest
 
 from custom_components.assist_canonicalizer import ranking
+from custom_components.assist_canonicalizer.bm25 import BM25Index
 from custom_components.assist_canonicalizer.candidate import (
     Candidate,
     CandidateSource,
@@ -38,8 +39,11 @@ from custom_components.assist_canonicalizer.ranking import (
     _positional_similarity,
     _query_slot_tokens_from_index,
     _query_token_coverage,
+    _rank_prefilter_keys,
+    _rank_prefilter_keys_with_sparse_bm25,
     _raw_cached_fuzz_ratio,
     _ScoringContext,
+    _top_prefilter_indices,
     accepted_candidate,
     clear_ranking_caches,
     confidence_gate_rejection_reason,
@@ -1151,6 +1155,109 @@ def test_rank_candidates_prefilters_rapidfuzz_work(monkeypatch) -> None:
     assert rapidfuzz_counter.calls == DEFAULT_RAPIDFUZZ_PREFILTER_CANDIDATES
 
 
+@pytest.mark.parametrize(
+    ("char_scores", "raw_bm25_scores"),
+    [
+        ([0.0, 0.5, 0.0, 0.2, 0.5, 0.0], [0.0, 0.1, 0.0, 0.6, 0.1, 0.0]),
+        ([0.0, 0.0, 0.4, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0]),
+        ([0.0, 0.0, 0.0, 0.0], [0.4, 0.0, 0.2, 0.0]),
+    ],
+)
+def test_sparse_bm25_prefilter_keys_match_dense(
+    char_scores: list[float],
+    raw_bm25_scores: list[float],
+) -> None:
+    """Preserve dense keys and selection while storing only touched BM25 scores."""
+    max_raw_score = max(raw_bm25_scores, default=0.0)
+    inv_max = 1.0 / max_raw_score if max_raw_score > 0.0 else 0.0
+    dense_bm25_scores = [score * inv_max for score in raw_bm25_scores]
+    sparse_bm25_scores = {
+        index: score for index, score in enumerate(raw_bm25_scores) if score > 0.0
+    }
+    dense_keys = _rank_prefilter_keys(char_scores, dense_bm25_scores)
+    hybrid_keys = _rank_prefilter_keys_with_sparse_bm25(
+        char_scores,
+        sparse_bm25_scores,
+        inv_max,
+    )
+
+    assert hybrid_keys == dense_keys
+    assert _top_prefilter_indices(hybrid_keys, len(hybrid_keys)) == _top_prefilter_indices(
+        dense_keys,
+        len(dense_keys),
+    )
+
+
+def test_prebuilt_static_bm25_matches_on_the_fly_sparse_ranking() -> None:
+    """Compare prebuilt and on-the-fly sparse-BM25 static ranking."""
+    candidates = [
+        Candidate(text="turn on kitchen light", intent_name="HassTurnOn", language="en"),
+        Candidate(text="turn off kitchen light", intent_name="HassTurnOff", language="en"),
+        Candidate(
+            text="set kitchen light to 50 percent", intent_name="HassLightSet", language="en"
+        ),
+        Candidate(text="turn on bedroom fan", intent_name="HassTurnOn", language="en"),
+        Candidate(text="open garage door", intent_name="HassTurnOn", language="en"),
+    ]
+    query = "turn kitchen light on"
+    normalized_texts = tuple(candidate.normalized_text for candidate in candidates)
+    bm25_index = BM25Index.from_normalized_texts(normalized_texts)
+    char_index = CharNGramIndex.from_grams(
+        tuple(ranking.char_ngrams_normalized(text) for text in normalized_texts)
+    )
+
+    dense_ranked = rank_candidates(query, candidates, max_candidates=5, language="en")
+    hybrid_ranked = rank_candidates(
+        query,
+        candidates,
+        max_candidates=5,
+        bm25_index=bm25_index,
+        candidate_char_index=char_index,
+        language="en",
+    )
+
+    assert [item.candidate for item in hybrid_ranked] == [item.candidate for item in dense_ranked]
+    assert [item.scores for item in hybrid_ranked] == [item.scores for item in dense_ranked]
+    assert accepted_candidate(hybrid_ranked) == accepted_candidate(dense_ranked)
+
+
+def test_reference_bm25_ranking_uses_dense_normalized_scores() -> None:
+    """Use normalized dense reference scores for dynamic candidate ranking."""
+    candidates = [
+        Candidate(text="turn on kitchen light", intent_name="HassTurnOn", language="en"),
+        Candidate(text="turn off kitchen fan", intent_name="HassTurnOff", language="en"),
+    ]
+    query = "turn on"
+    query_tokens = tuple(normalize_text(query).split())
+    reference_bm25_index = BM25Index.from_normalized_texts(
+        ("turn on hall light", "turn off garage fan", "set bedroom temperature")
+    )
+    expected_scores = reference_bm25_index.score_custom_documents_tokens(
+        query_tokens,
+        candidates,
+    )
+
+    scoring = ranking._prepare_bm25_scoring(
+        candidates,
+        query_tokens,
+        None,
+        reference_bm25_index,
+    )
+    ranked = rank_candidates(
+        query,
+        candidates,
+        max_candidates=2,
+        reference_bm25_index=reference_bm25_index,
+        language="en",
+    )
+
+    assert scoring.sparse_raw_scores is None
+    assert tuple(scoring.score_at(index) for index in range(len(candidates))) == expected_scores
+    assert {item.candidate: item.scores.bm25_score for item in ranked} == dict(
+        zip(candidates, expected_scores, strict=True)
+    )
+
+
 def test_rank_candidates_validates_candidate_slot_token_length() -> None:
     """Reject precomputed slot-token data that does not match the candidate list."""
     candidates = [Candidate(text="turn on kitchen light", intent_name="HassTurnOn")]
@@ -1161,6 +1268,15 @@ def test_rank_candidates_validates_candidate_slot_token_length() -> None:
             candidates,
             candidate_slot_tokens=(),
         )
+
+
+def test_rank_candidates_validates_static_bm25_index_length() -> None:
+    """Reject a sparse BM25 index not built from the candidate sequence."""
+    candidates = [Candidate(text="turn on kitchen light", intent_name="HassTurnOn")]
+    bm25_index = BM25Index.from_normalized_texts(("turn on kitchen light", "turn off fan"))
+
+    with pytest.raises(ValueError, match="bm25_index length must match candidates"):
+        rank_candidates("turn on kitchen light", candidates, bm25_index=bm25_index)
 
 
 def test_rapidfuzz_similarity_penalizes_extra_area_tokens() -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import sys
+import threading
 from collections.abc import Mapping
 from enum import Enum
 from types import ModuleType
@@ -1190,6 +1191,314 @@ async def test_async_rebuild_does_not_publish_after_index_clear(monkeypatch: Any
     assert index is None
     assert runtime.get_index("en") is None
     assert "assist_canonicalizer.index_en" not in MockStore.stored_data
+    assert runtime.rebuild_tasks == {}
+
+
+async def test_async_shutdown_prevents_blocked_rebuild_publication(monkeypatch: Any) -> None:
+    """Do not publish or persist a rebuild that finishes after runtime shutdown starts."""
+    monkeypatch.setattr(homeassistant.helpers.storage, "Store", MockStore)
+    MockStore.reset()
+    runtime = CanonicalizerRuntime()
+    build_started = threading.Event()
+    build_finished = threading.Event()
+    release_build = threading.Event()
+    save_called = False
+    set_index_called = False
+
+    def blocking_build(snapshot: Any) -> CanonicalIndex:
+        """Block inside executor-backed index construction."""
+        build_started.set()
+        assert release_build.wait(timeout=5)
+        build_finished.set()
+        return build_index(
+            snapshot.language,
+            [Candidate(text="turn on light", intent_name="HassTurnOn", language=snapshot.language)],
+        )
+
+    class ThreadedBuildHass(HashableFakeHass):
+        """Fake hass that runs the build step in a real executor thread."""
+
+        def async_create_task(self, coro: Any) -> asyncio.Task[Any]:
+            """Create an asyncio task."""
+            return asyncio.create_task(coro)
+
+        async def async_add_executor_job(self, target: Any, *args: Any) -> Any:
+            """Run the blocked build in an executor thread."""
+            if target is blocking_build:
+                loop = asyncio.get_running_loop()
+                return await loop.run_in_executor(None, target, *args)
+            return target(*args)
+
+    original_save = CanonicalizerRuntime.async_save_index_to_store
+
+    async def record_save(
+        self: CanonicalizerRuntime,
+        *args: Any,
+        **kwargs: Any,
+    ) -> bool:
+        """Record unexpected persistence attempts."""
+        nonlocal save_called
+        if self is runtime:
+            save_called = True
+        return await original_save(self, *args, **kwargs)
+
+    original_set_index = CanonicalizerRuntime.set_index
+
+    def record_set_index(self: CanonicalizerRuntime, index: CanonicalIndex) -> None:
+        """Record unexpected in-memory publication attempts."""
+        nonlocal set_index_called
+        if self is runtime:
+            set_index_called = True
+            return
+        original_set_index(self, index)
+
+    monkeypatch.setattr(runtime_module, "_build_index_from_snapshot", blocking_build)
+    monkeypatch.setattr(CanonicalizerRuntime, "async_save_index_to_store", record_save)
+    monkeypatch.setattr(CanonicalizerRuntime, "set_index", record_set_index)
+    hass = ThreadedBuildHass()
+
+    rebuild_task = asyncio.create_task(runtime.async_rebuild_index(hass, "en"))
+    assert await asyncio.to_thread(build_started.wait, 5)
+    shutdown_task = asyncio.create_task(runtime.async_shutdown())
+    await asyncio.sleep(0)
+    release_build.set()
+
+    try:
+        rebuild_result = await rebuild_task
+    except asyncio.CancelledError:
+        rebuild_result = None
+    await shutdown_task
+
+    assert rebuild_result is None
+    assert build_finished.is_set()
+    assert not save_called
+    assert not set_index_called
+    assert runtime.get_index("en") is None
+    assert "assist_canonicalizer.index_en" not in MockStore.stored_data
+    assert runtime.rebuild_tasks == {}
+
+
+async def test_async_shutdown_waits_for_active_store_operation(monkeypatch: Any) -> None:
+    """Use the storage lock as a barrier for saves that already started."""
+    save_started = asyncio.Event()
+    release_save = asyncio.Event()
+
+    class BlockingSaveStore(MockStore):
+        """Mock store that blocks index saves until released."""
+
+        async def async_save(self, data: dict[str, Any]) -> None:
+            """Block the language index save to test the shutdown barrier."""
+            if self.key == "assist_canonicalizer.index_en":
+                save_started.set()
+                await release_save.wait()
+            await super().async_save(data)
+
+    monkeypatch.setattr(homeassistant.helpers.storage, "Store", BlockingSaveStore)
+    BlockingSaveStore.reset()
+    runtime = CanonicalizerRuntime()
+    hass = HashableFakeHass()
+    index = build_index("en", [Candidate(text="turn on light", intent_name="HassTurnOn")])
+
+    save_task = asyncio.create_task(runtime.async_save_index_to_store(hass, index, "fingerprint"))
+    await save_started.wait()
+    shutdown_task = asyncio.create_task(runtime.async_shutdown())
+    await asyncio.sleep(0)
+
+    assert not shutdown_task.done()
+
+    release_save.set()
+    assert await save_task is False
+    await shutdown_task
+    assert "assist_canonicalizer.index_manifest" not in BlockingSaveStore.stored_data
+
+
+async def test_async_shutdown_drains_cancelled_rebuild_store_writer(monkeypatch: Any) -> None:
+    """Wait for executor-backed storage even when shutdown cancels its rebuild."""
+    save_started = threading.Event()
+    release_save = threading.Event()
+    save_finished = threading.Event()
+
+    class ExecutorBackedSaveStore(MockStore):
+        """Mock a Home Assistant store whose file write runs in an executor."""
+
+        async def async_save(self, data: dict[str, Any]) -> None:
+            """Run the language-store write in a thread that cancellation cannot stop."""
+            if self.key != "assist_canonicalizer.index_en":
+                await super().async_save(data)
+                return
+
+            def blocking_write() -> None:
+                """Block the executor writer until the test releases it."""
+                save_started.set()
+                assert release_save.wait(timeout=5)
+                MockStore.stored_data[self.key] = data
+                save_finished.set()
+
+            await asyncio.get_running_loop().run_in_executor(None, blocking_write)
+
+    monkeypatch.setattr(homeassistant.helpers.storage, "Store", ExecutorBackedSaveStore)
+    MockStore.reset()
+    runtime = CanonicalizerRuntime()
+    hass = HashableFakeHass(async_create_task=lambda coro: asyncio.create_task(coro))
+
+    rebuild_task = asyncio.create_task(runtime.async_rebuild_index(hass, "en"))
+    assert await asyncio.to_thread(save_started.wait, 5)
+    shutdown_task = asyncio.create_task(runtime.async_shutdown())
+    await asyncio.sleep(0.05)
+
+    assert not shutdown_task.done()
+    assert not save_finished.is_set()
+
+    release_save.set()
+    await asyncio.gather(rebuild_task, return_exceptions=True)
+    await shutdown_task
+
+    assert save_finished.is_set()
+    assert "assist_canonicalizer.index_en" in MockStore.stored_data
+    assert "assist_canonicalizer.index_manifest" not in MockStore.stored_data
+
+
+async def test_async_shutdown_drains_direct_store_load_build(monkeypatch: Any) -> None:
+    """Wait for a direct persisted-index build before completing shutdown."""
+    monkeypatch.setattr(homeassistant.helpers.storage, "Store", MockStore)
+    MockStore.reset()
+    hass = HashableFakeHass()
+    source_runtime = CanonicalizerRuntime()
+    snapshot = _create_build_snapshot_and_register_wildcards(
+        "en",
+        *source_runtime._capture_build_inputs(),
+    )
+    stored_index = build_index(
+        "en",
+        [Candidate(text="turn on light", intent_name="HassTurnOn", language="en")],
+    )
+    assert await source_runtime.async_save_index_to_store(
+        hass,
+        stored_index,
+        snapshot.fingerprint,
+    )
+
+    build_started = threading.Event()
+    release_build = threading.Event()
+    build_finished = threading.Event()
+
+    def blocking_build(language: str, candidates: Any) -> CanonicalIndex:
+        """Block reconstruction of the loaded index in a real executor thread."""
+        build_started.set()
+        assert release_build.wait(timeout=5)
+        rebuilt = build_index(language, candidates)
+        build_finished.set()
+        return rebuilt
+
+    class ThreadedLoadHass(HashableFakeHass):
+        """Fake hass that runs persisted-index reconstruction in an executor."""
+
+        async def async_add_executor_job(self, target: Any, *args: Any) -> Any:
+            """Run only the patched index builder in a real executor thread."""
+            if target is blocking_build:
+                return await asyncio.get_running_loop().run_in_executor(None, target, *args)
+            return target(*args)
+
+    monkeypatch.setattr(runtime_module, "build_index", blocking_build)
+    runtime = CanonicalizerRuntime()
+    load_task = asyncio.create_task(runtime.async_load_index_from_store(ThreadedLoadHass(), "en"))
+    assert await asyncio.to_thread(build_started.wait, 5)
+    shutdown_task = asyncio.create_task(runtime.async_shutdown())
+    await asyncio.sleep(0.05)
+
+    assert not shutdown_task.done()
+    assert not build_finished.is_set()
+
+    release_build.set()
+    assert await load_task is None
+    await shutdown_task
+
+    assert build_finished.is_set()
+    assert runtime.get_index("en") is None
+
+
+async def test_async_shutdown_cancels_and_drains_rebuild_tasks() -> None:
+    """Cancel and await all tracked per-language rebuild tasks."""
+    runtime = CanonicalizerRuntime()
+
+    async def pending_rebuild() -> CanonicalIndex | None:
+        """Never finish unless canceled by shutdown."""
+        await asyncio.Event().wait()
+        return None
+
+    task_en = asyncio.create_task(pending_rebuild())
+    task_vi = asyncio.create_task(pending_rebuild())
+    runtime.rebuild_tasks["en"] = (runtime.index_generation, task_en)
+    runtime.rebuild_tasks["vi"] = (runtime.index_generation, task_vi)
+
+    await runtime.async_shutdown()
+
+    assert task_en.cancelled()
+    assert task_vi.cancelled()
+    assert runtime.rebuild_tasks == {}
+    assert runtime.warmup_tasks == set()
+
+
+async def test_async_shutdown_cancels_and_drains_tracked_warmup_task() -> None:
+    """Cancel and await a warmup registered through the public tracking API."""
+    runtime = CanonicalizerRuntime()
+    warmup_started = asyncio.Event()
+
+    async def pending_warmup() -> None:
+        """Remain active until runtime shutdown cancels the warmup."""
+        warmup_started.set()
+        await asyncio.Event().wait()
+
+    warmup_task = asyncio.create_task(pending_warmup())
+    runtime.track_warmup_task(warmup_task)
+    await warmup_started.wait()
+
+    assert warmup_task in runtime.warmup_tasks
+
+    await runtime.async_shutdown()
+
+    assert warmup_task.cancelled()
+    assert runtime.warmup_tasks == set()
+
+
+async def test_async_await_drained_retries_repeated_cancellation() -> None:
+    """Drain work after every cancellation delivered while it remains active."""
+    work_started = asyncio.Event()
+    release_work = asyncio.Event()
+    work_finished = asyncio.Event()
+
+    async def pending_work() -> None:
+        """Block until the test permits the drained operation to complete."""
+        work_started.set()
+        await release_work.wait()
+        work_finished.set()
+
+    drain_task = asyncio.create_task(runtime_module._async_await_drained(pending_work()))
+    await work_started.wait()
+
+    drain_task.cancel()
+    await asyncio.sleep(0)
+    drain_task.cancel()
+    await asyncio.sleep(0)
+
+    assert not drain_task.done()
+
+    release_work.set()
+    with pytest.raises(asyncio.CancelledError):
+        await drain_task
+
+    assert work_finished.is_set()
+
+
+async def test_async_rebuild_index_returns_none_after_shutdown() -> None:
+    """Do not create rebuild work after the runtime is closed."""
+    runtime = CanonicalizerRuntime()
+    await runtime.async_shutdown()
+    hass = HashableFakeHass(async_create_task=lambda coro: pytest.fail("no task expected"))
+
+    result = await runtime.async_rebuild_index(hass, "en")
+
+    assert result is None
     assert runtime.rebuild_tasks == {}
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -538,30 +538,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.44"
+version = "1.43.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/bd/4d27e9002536dcf85cf97126d4fe93cc01f3a73000f14408ec51554231ca/boto3-1.43.44.tar.gz", hash = "sha256:035d73afe3e29bf271a5b27b30476ff8eefa5ae36f6702eada8e412d5c1420aa", size = 112697, upload-time = "2026-07-09T00:38:47.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/c0/bcbe0a924ed89f8982a87727cd0f88a73397fa423a60df17ae76aa013514/boto3-1.43.45.tar.gz", hash = "sha256:65e0ae541a9948ac41b706d5c7165d96ebf155812562b6518b862be027ee7347", size = 112666, upload-time = "2026-07-09T19:30:06.944Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/f2/48081d32e813b14ec03495737984208f193d9a102820b25844c61c94d827/boto3-1.43.44-py3-none-any.whl", hash = "sha256:621113f7850caec7c8405a07baa26075f700f78844a7f2fdf4d1f879bd3cc3c1", size = 140029, upload-time = "2026-07-09T00:38:45.63Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/0d7d1e537d301cf0d079fa4a0765c9febf0eb74d65c115cababa6368c1b3/boto3-1.43.45-py3-none-any.whl", hash = "sha256:bb076647526c491ce75cab896543afcda5b81c97d3f8e8da08a033fc1ddb7429", size = 140031, upload-time = "2026-07-09T19:30:04.87Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.44"
+version = "1.43.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/9e/ad63ae4996794be10afef4e1b2f98901947da65c6c349be9c063ee73edbf/botocore-1.43.44.tar.gz", hash = "sha256:cc2a95a53efdcf0ce34a51bca28058e72fcc3b10dd625eb1ad900c5ca3eb8bef", size = 15685774, upload-time = "2026-07-09T00:38:36.71Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/fa/fb07ee4025ec257ff7b45d40411a922c86da3a4eaa98783da74404071d99/botocore-1.43.45.tar.gz", hash = "sha256:a2da80ff3caa2873769b9a32ae5f1fb18b3571ab63a981896639955611ca01e6", size = 15689068, upload-time = "2026-07-09T19:29:55.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/05/5c5de6ed23b5e1b01e36b9e52f056dc2b09b259daf3371e4b615ad9a1d4a/botocore-1.43.44-py3-none-any.whl", hash = "sha256:6afb846fd93815133a53baf1578f1d6016ddbeda247623360379758ca2e3f338", size = 15374229, upload-time = "2026-07-09T00:38:33.716Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a5/ac3ca5d2d42456eb497a4aafc6b1b15502b0817299ca8fc7c9bd7969c301/botocore-1.43.45-py3-none-any.whl", hash = "sha256:a04871d814124e65daf429fb99640def23b8c4d3edc6438603b31f11116d7a67", size = 15376233, upload-time = "2026-07-09T19:29:52.312Z" },
 ]
 
 [[package]]
@@ -2297,27 +2297,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.20"
+version = "0.15.21"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
-    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
-    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
-    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
-    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
-    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
-    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
-    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
 ]
 
 [[package]]
@@ -2519,27 +2519,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.57"
+version = "0.0.58"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/16/d01c968d405acae51c07872e80f30f3a586235bdf52c9847ca0917a230a3/ty-0.0.57.tar.gz", hash = "sha256:bc058f564868690283a0420d09c269ec8be21e8e43b4b49ee975a17623092e44", size = 6100787, upload-time = "2026-07-08T11:33:59.904Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/4c/26c90732658903aeb1d289208f7b7b492fa21029e0c4d6c51bdd6f8f5e51/ty-0.0.58.tar.gz", hash = "sha256:8f22484174e65c630660a454bf81b80cae7a3a7e70479f19c170d6cd87949258", size = 6133665, upload-time = "2026-07-10T03:09:30.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/9c/a7948b05f2a3f43d511f88ef5c4f56d7edb8acc8caa5f56d7c5831f52c84/ty-0.0.57-py3-none-linux_armv6l.whl", hash = "sha256:cb6d3371dd8c78950b75bee31a36b94564a54a1f0eecafbbf05715ac1a5287d6", size = 11760058, upload-time = "2026-07-08T11:33:18.671Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/92/3776380decba3965bcaa1ea2b56f5b133aa3ef549bfbe4b79eb122dcc15d/ty-0.0.57-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e58b90491a48ec757bd50f512f3eb92c1c64b7d46a4db83677e9b60222e1d2bb", size = 11492105, upload-time = "2026-07-08T11:33:21.267Z" },
-    { url = "https://files.pythonhosted.org/packages/13/be/912f8422d06fd1e29805a7c781e3ce4c821917e0e3d00f0cf176c0529469/ty-0.0.57-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dbb8207f75122c658ca21bf405cea8202e490240440461ae3e0c5a6f67ae668f", size = 11078675, upload-time = "2026-07-08T11:33:23.804Z" },
-    { url = "https://files.pythonhosted.org/packages/06/86/6ed526df554b491ce3d07bbec04f7a10304243bc994ab989352c85134b1e/ty-0.0.57-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:651243f391809de80b01be1729c5d0cecc7b952d7d22cfbf56f0b4f069703195", size = 11614379, upload-time = "2026-07-08T11:33:26.041Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/95/78af20f309abce31fa616e0142f85756e665a9965669b823181ff695ffec/ty-0.0.57-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:28c5392bbd7c4d6a4c1b1646a709231db675dc094f49bf71b7de83757125e93b", size = 11563854, upload-time = "2026-07-08T11:33:28.144Z" },
-    { url = "https://files.pythonhosted.org/packages/88/dc/bf9231d5563b9e61a1eec9782184a4055afaa87259644cd9ed1376a7dc5c/ty-0.0.57-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8d981535094ab492aaef6f71d9348bcf90e42e6de4cb50de2dd7fbabd8378360", size = 12229897, upload-time = "2026-07-08T11:33:30.262Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/dd/012008190a997097ebe500b9704baaad9135bfa033b9530a9b8f69f1d11f/ty-0.0.57-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:719b41fd6df61352866cad952d7bfb4873c893a70e806d37d0f1d30ad4f26cd5", size = 12816002, upload-time = "2026-07-08T11:33:32.747Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/2f/0e42c361e38e04747ed2b3d3299512edd4ea6060d8e3124e3c6f2d2465a1/ty-0.0.57-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a1641a609b025e13f44115c7071b39b02675044a78fbfedef239a5f7da50b393", size = 12323420, upload-time = "2026-07-08T11:33:35.426Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/01/18f1e03108d1ae8e515c92fb304994a66eaafd47037f928fd42fd3a1e29d/ty-0.0.57-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a33f96a9dd6919fe8b1d3512cd99f16be4a51388f265de135fea2c2fbf0b4317", size = 12119481, upload-time = "2026-07-08T11:33:37.808Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/48/570b73fb3e32554ff03aa9f6650b33a504cdfa027a8b50a5ab087e56b20d/ty-0.0.57-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f0a1014a922b2b7f79a46e5cdbaa6feb7403a444631292b8666382a98a04de20", size = 12427299, upload-time = "2026-07-08T11:33:39.964Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/37/76b27f6a92e12525d09cd65d3c3b5aea419cf4782b13320db95ac3d310f0/ty-0.0.57-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d73aaed84023bf682819f871377b255fae9098898c50475426ac9bdfcd986872", size = 11562292, upload-time = "2026-07-08T11:33:42.392Z" },
-    { url = "https://files.pythonhosted.org/packages/84/8b/d0c398147b00f336595e1a00a5895b3924251205c11b8d73cb0668281f1c/ty-0.0.57-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f3e2104704063c00ab8a757af3e95378b32624a3e8d8149aad5251877bf82959", size = 11565833, upload-time = "2026-07-08T11:33:44.778Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/74/dab9745e977ef38751ec710f74e40d21fddbd04a80338dd5597c98899eed/ty-0.0.57-py3-none-musllinux_1_2_i686.whl", hash = "sha256:07ad760763646d8f1567ea5d899e6d217212acd8539b7afed5a370d93693553b", size = 11864967, upload-time = "2026-07-08T11:33:47.36Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/57/350812143b49dac7aa655f40a1f45d4821ca9b56b75d9b68d5e603269044/ty-0.0.57-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b4a6e1f0fee7df3e65fb0b9cbe9f99a4be39198558ed9aacc31a98d210ad7bcc", size = 12239054, upload-time = "2026-07-08T11:33:49.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/d0/b3e3d9c6cce3debda6247aa435e81d18ec62fabfec13f35f6c6957066f47/ty-0.0.57-py3-none-win32.whl", hash = "sha256:f8d488c0535a8f0386dbe2c9bcb31d467ae0c68d0c9945113018937828ebaabb", size = 11225353, upload-time = "2026-07-08T11:33:52.569Z" },
-    { url = "https://files.pythonhosted.org/packages/77/db/6ce240ee31413f9dc7467e31377553e92e2664252ee7d33aa9290a7a94bb/ty-0.0.57-py3-none-win_amd64.whl", hash = "sha256:de9529a7dcc3e529b08c14634dc4e7066ebea5cd55006afc02bde8033efe7c91", size = 12272419, upload-time = "2026-07-08T11:33:54.889Z" },
-    { url = "https://files.pythonhosted.org/packages/44/de/48662fa2c42289f309eeb8b5539cbe840e10002b65ac0700cb7889e92532/ty-0.0.57-py3-none-win_arm64.whl", hash = "sha256:7f3352777ce40c4906145f3c3e10b71716d8d35c0c9e3a0070d84f61dda0755f", size = 11686309, upload-time = "2026-07-08T11:33:57.246Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e1/5d1aa2a75829459834689f080e4be7a9d8828ce14b939ebed69161a35811/ty-0.0.58-py3-none-linux_armv6l.whl", hash = "sha256:47412850b6fbef61c42f244f6a51aa2f2c9e91f08cfbafd2d1e3730d2419d317", size = 11706915, upload-time = "2026-07-10T03:08:51.028Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e1/929eda9cc72a9afe39a03c76f946a503508d37343cc8ff2e64226afda105/ty-0.0.58-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79deb7bb4e5b3a1eee6ab9abc724d6ce3559d4977982707f310a139ee11fc703", size = 11532079, upload-time = "2026-07-10T03:08:53.771Z" },
+    { url = "https://files.pythonhosted.org/packages/07/43/ebc58b3fc7d86a7abba2829f1674f7d4ae3a08f9794c1f31b707950c871f/ty-0.0.58-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a28af3187e661708a386d44a4fc32896a5f589fb07b734a11ab2f516e7572b7", size = 11092983, upload-time = "2026-07-10T03:08:56.025Z" },
+    { url = "https://files.pythonhosted.org/packages/92/6e/9547dbb8e51e47749cfb721a02b4fc862f9a932fa0f66a34a4d6dc429bb1/ty-0.0.58-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21a6977e34bc362fb378add46e59d5d56331c1c36727e6904767217ca8479718", size = 11490492, upload-time = "2026-07-10T03:08:58.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/76/9f83b51b5e7795d6c8d76b4bb1bb7cebf4c10d609e846c02ab138e404556/ty-0.0.58-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ac23e6bf6105ceca46632debf1b10b98125aaf60202aeae02f6abfeea242b3d", size = 11503696, upload-time = "2026-07-10T03:09:00.741Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9d/9fd48a0696c680f74e50f31cd54e524eeb58c97ea9bb1c3b8e04230ba215/ty-0.0.58-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb6df6a8c6a21894807a49851370ec7fc64aa910296c78ada31db0ef19359112", size = 12158653, upload-time = "2026-07-10T03:09:02.998Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/ea/b5de845d2d8edae04d901c7585af7f04a057e18b26311f7fa4ca62b2da30/ty-0.0.58-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9df5847eebc026cde088b44420a03f7c6c169a7db747176bdf0a656eb1144713", size = 12723019, upload-time = "2026-07-10T03:09:05.291Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1c/54083b23eeff1e101f50b6df6a2c7f1e14b31abe0577c91bcae9e2c9395d/ty-0.0.58-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53a331a7f1f85872c810676a0f16096ef98c1b95c8c9a573fe7fde64d0a93e7c", size = 12275715, upload-time = "2026-07-10T03:09:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/22/88/16925434b06faa49d36aa7e7508a6821ec6feacb429ca2fd80a3d52716b4/ty-0.0.58-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb0b05cd479fdcedc2e6781d376ee1a33569f37ae7f58357004635f615c4374c", size = 12033075, upload-time = "2026-07-10T03:09:10.222Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2b/b55708dd483982ae03d14da3667e3f0346cd384e11cca3dd3674a8b598c1/ty-0.0.58-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a0012786077e5becbb6add9fe51eda1d4d36d249afd3ae6cd141d554af15ae3", size = 12367729, upload-time = "2026-07-10T03:09:12.338Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a3/99ad66652956408f7e9ac3db6b4a416199d773b6c073cf95b0eea126d340/ty-0.0.58-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4ede96d7f6d149156da254e784b062b817736b68d4c6d660555a3d02d96966fb", size = 11439798, upload-time = "2026-07-10T03:09:14.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/23/344ceed4fe02ed498711e1f4a47b6e311fb1e9c4fecc19d31894be7a3472/ty-0.0.58-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:47608e58f73901b989402e6f283249cda4c2314282ec368aa74ab61761c62bd5", size = 11512695, upload-time = "2026-07-10T03:09:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/55/cf/3801831812c468f3fd0b3043a80f557a9aa90e6c27375763d7c3121e03f2/ty-0.0.58-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9757de17cc17e4c6bc26e18d4e26dea52ffee53d41a10d9087c6465e6ab12e2b", size = 11812253, upload-time = "2026-07-10T03:09:19.151Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/80/bce4f245787b77d1ec9feec7d9161eade5e01a77dbc132e016b24df83b0d/ty-0.0.58-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f3776d54c1d935fcb8f814bd58efba402c86c555f93e1144c59d087e7aa8b906", size = 12123918, upload-time = "2026-07-10T03:09:21.636Z" },
+    { url = "https://files.pythonhosted.org/packages/46/00/bab3d6268e7e88c792bf7cdde81bd11b31aa587eaba75196502b729747c8/ty-0.0.58-py3-none-win32.whl", hash = "sha256:8f50ec0ac3b42baa4c75895dc367071dc86b00ab440d29fdc72c633286a94815", size = 11230897, upload-time = "2026-07-10T03:09:23.871Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/68/d9504c895864aaa84a840dce6ac7f8e681f6938be1882c8d4f60832dbe57/ty-0.0.58-py3-none-win_amd64.whl", hash = "sha256:de8847b3a65475ae4773bddd3126bfcf29f017e88967c4dcc9c75d743a4d3e5c", size = 12299376, upload-time = "2026-07-10T03:09:26.292Z" },
+    { url = "https://files.pythonhosted.org/packages/26/04/c9847cb680b5fe8e1f7d7b483edd5cedcc29394496e7b8ed40d96be796ba/ty-0.0.58-py3-none-win_arm64.whl", hash = "sha256:7334bb38789878f60677f2eb9c1de4bfdf4583e2443790989c77da9b10fe0989", size = 11710495, upload-time = "2026-07-10T03:09:28.478Z" },
 ]
 
 [[package]]
@@ -2565,11 +2565,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.2"
+version = "2026.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Harden the canonicalizer runtime shutdown lifecycle and BM25 ranking, ensuring no new work is admitted or published after shutdown while improving BM25 scoring efficiency and test coverage.

New Features:
- Add sparse BM25 scoring and hybrid ranking support to reuse prebuilt BM25 indexes while preserving dense scoring semantics.
- Introduce runtime warmup task tracking and coordinated shutdown that cancels and drains rebuild and warmup tasks.

Bug Fixes:
- Prevent index rebuilds, storage operations, and ranking from mutating state after the runtime has begun shutting down.
- Ensure shutdown waits for in-flight storage and index load operations, including executor-backed work, before clearing caches.
- Fix exact-text collision handling to delegate to HassIL with full original context and to fall back to raw text when validation fails.
- Validate that provided static BM25 indexes match the candidate list length to avoid misaligned scoring.

Enhancements:
- Guard most runtime entry points with a closed flag and generation checks to enforce lifecycle invariants.
- Refine storage access by routing critical operations through cancellation-resilient helpers and tracking active index loads.
- Factor BM25 scoring into a reusable helper and dataclass to separate dense and sparse representations and simplify ranking logic.
- Adjust pipeline warmup to run language warmups via an async task group and await completion instead of fire-and-forget tasks.

CI:
- Broaden CI triggers to run on additional file types, including JSON and YAML, for both pushes and pull requests.

Documentation:
- Document BM25 index usage expectations and exact match delegation behavior in docstrings and tests.

Tests:
- Add extensive runtime shutdown tests covering rebuild cancellation, storage barriers, executor-backed operations, and post-shutdown behavior.
- Add tests verifying sparse BM25 raw scores and prefilter keys are equivalent to dense paths and that hybrid ranking matches the existing oracle.
- Extend conversation tests to cover exact-text collision delegation to HassIL and validation fallback behavior.
- Update warmup tests to assert awaited per-language warmups instead of spawned tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened shutdown lifecycle to block new work and drain in-flight index build and persisted storage tasks safely.
  - Prevented late-running warmup, registry refreshes, and intent updates after shutdown begins.
  - Improved exact-text collision handling with HassIL delegation and deterministic fallback on validation failure.
- **Performance**
  - Added sparse BM25 scoring optimized to compute only affected documents during ranking.
- **Quality Improvements**
  - Expanded ranking, BM25, runtime shutdown, warmup, and conversation collision test coverage.
- **Chores**
  - Tightened CI trigger filters and bumped Prettier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->