### PR TITLE
Align the same format for consistency across the two parallel CI workflows

### DIFF
--- a/tools/validate_compatibility.py
+++ b/tools/validate_compatibility.py
@@ -595,7 +595,7 @@ def _overrides_file(ha_ver: str) -> Generator[str]:
     os.makedirs(overrides_dir, exist_ok=True)
     overrides_path = os.path.join(overrides_dir, f"overrides_{uuid.uuid4().hex}.txt")
     with open(overrides_path, "w", encoding="utf-8") as f:
-        f.write(f"homeassistant == {ha_ver}\n")
+        f.write(f"homeassistant=={ha_ver}\n")
     try:
         yield overrides_path
     finally:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Standardize the generated overrides file to use compact `homeassistant==<version>` formatting for dependency pins.