### PR TITLE
Keep wildcard rehydration in-memory and non-blocking, fix blocking calls in the event loop when loading intents

### DIFF
--- a/custom_components/assist_canonicalizer/conversation.py
+++ b/custom_components/assist_canonicalizer/conversation.py
@@ -34,8 +34,8 @@ from .const import (
     NAME,
     FallbackReason,
 )
-from .grammar_loader import rehydrate_wildcard_text
 from .ranking import RankedCandidate, evaluate_confidence_gates
+from .rehydration import get_wildcard_rehydration
 from .runtime import CanonicalizerRuntime
 from .utils import (
     elapsed_ms,
@@ -386,7 +386,7 @@ class AssistCanonicalizerConversationEntity(
 
         candidate = ranked_candidate.candidate
         candidate_text = candidate.text
-        rehydrated = rehydrate_wildcard_text(candidate_text, user_input.text, user_input.language)
+        rehydrated, _replacements = get_wildcard_rehydration(candidate, user_input.text)
         if candidate.has_wildcard and rehydrated == candidate_text:
             return None
 

--- a/custom_components/assist_canonicalizer/runtime.py
+++ b/custom_components/assist_canonicalizer/runtime.py
@@ -50,8 +50,6 @@ from .utils import (
     clear_utils_caches,
     normalize_language,
     register_custom_wildcards_from_sources,
-    wildcard_slot_names,
-    wildcard_slot_names_sorted,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -870,20 +868,10 @@ def _create_build_snapshot_and_register_wildcards(
     subscribed_sources: dict[str, Mapping[str, Any]],
     registry_slot_values: dict[str, tuple[str, ...]],
 ) -> IndexBuildSnapshot:
-    """Load candidate sources, register custom wildcards, and fingerprint build inputs.
-
-    Side Effects:
-    - Registers custom wildcard slots for the target language to global state.
-    - Pre-warms the wildcard slot name caches (``wildcard_slot_names`` and
-      ``wildcard_slot_names_sorted``) so that subsequent event-loop calls to
-      ``rehydration`` and ``grammar_loader`` always hit a warm cache and never
-      trigger the blocking ``open()`` call inside ``home_assistant_intents.get_intents``.
-    """
+    """Load sources, register in-memory wildcards, and fingerprint build inputs."""
     sources = load_language_intent_sources(language, config_path=config_path)
     sources.update(subscribed_sources)
     register_custom_wildcards_from_sources(language, sources)
-    wildcard_slot_names(language)
-    wildcard_slot_names_sorted(language)
     dynamic_registry_intents = compile_dynamic_registry_intents(
         sources,
         language,

--- a/custom_components/assist_canonicalizer/services.py
+++ b/custom_components/assist_canonicalizer/services.py
@@ -36,10 +36,10 @@ from .const import (
     SERVICE_REBUILD_INDEX,
     SERVICE_TEST_MATCH,
 )
-from .grammar_loader import rehydrate_wildcard_text
 from .indexer import CanonicalIndex
 from .normalization import normalize_text
 from .ranking import RankedCandidate, accepted_candidate
+from .rehydration import get_wildcard_rehydration
 from .runtime import CanonicalizerRuntime
 from .utils import elapsed_ms, normalize_language, resolve_entry_thresholds
 
@@ -380,7 +380,7 @@ def _ranked_candidate_response(ranked: RankedCandidate, query: str | None = None
     text = candidate.text
     normalized_text = candidate.normalized_text
     if query is not None:
-        text = rehydrate_wildcard_text(text, query, candidate.language)
+        text, _replacements = get_wildcard_rehydration(candidate, query)
         normalized_text = normalize_text(text)
     return {
         ATTR_TEXT: text,

--- a/custom_components/assist_canonicalizer/utils.py
+++ b/custom_components/assist_canonicalizer/utils.py
@@ -8,7 +8,9 @@ from collections.abc import Mapping
 from functools import lru_cache
 from math import isclose
 from string import whitespace
+from threading import Lock
 from time import monotonic
+from types import MappingProxyType
 from typing import Any
 
 from .builtin_intents import language_variant_for
@@ -39,7 +41,11 @@ _TENTHS_FRACTIONS = (
 _STRIPPED_CHARS = "".join(PRESERVED_UNIT_SUFFIXES) + whitespace
 _HAS_DIGIT_RE = re.compile(r"\d")
 
-_CUSTOM_WILDCARD_SLOTS: dict[str, set[str]] = {}
+# Readers retain immutable snapshots while writers publish a replacement under the lock.
+_EMPTY_WILDCARD_NAMES: frozenset[str] = frozenset()
+_EMPTY_WILDCARD_REGISTRY: Mapping[str, frozenset[str]] = MappingProxyType({})
+_CUSTOM_WILDCARD_SLOTS: Mapping[str, frozenset[str]] = _EMPTY_WILDCARD_REGISTRY
+_CUSTOM_WILDCARD_SLOTS_LOCK = Lock()
 NormalizedIntentContext = Mapping[str, frozenset[str]]
 
 
@@ -75,6 +81,15 @@ def normalize_language(language: str) -> str:
     if language_variant is not None:
         return language_variant
     return requested.replace("_", "-").lower()
+
+
+def _wildcard_language_key(language: str) -> str:
+    """Return a memory-only wildcard registry key with unknown-language fallback."""
+    if not isinstance(language, str):
+        raise ValueError("Language must be a non-empty string")
+    if requested := language.strip():
+        return requested.replace("_", "-").lower()
+    raise ValueError("Language must not be empty")
 
 
 def intent_context_from_area_name(area_name: str | None) -> dict[str, dict[str, str]] | None:
@@ -119,9 +134,7 @@ def normalize_intent_context(
 def register_custom_wildcards_from_sources(
     language: str | None, intent_sources: Mapping[str, Mapping[str, Any]]
 ) -> None:
-    """Extract wildcard slot names from intent sources and register them."""
-    if not intent_sources:
-        return
+    """Replace one language's in-memory wildcard names from loaded intent sources."""
     wildcards: set[str] = set()
     for source_config in intent_sources.values():
         lists = source_config.get("lists", {})
@@ -129,21 +142,43 @@ def register_custom_wildcards_from_sources(
             for name, list_config in lists.items():
                 if isinstance(list_config, Mapping) and list_config.get("wildcard"):
                     wildcards.add(name)
-    if wildcards:
-        try:
-            norm_lang = normalize_language(language) if language else ""
-        except ValueError:
-            norm_lang = ""
-        if norm_lang not in _CUSTOM_WILDCARD_SLOTS:
-            _CUSTOM_WILDCARD_SLOTS[norm_lang] = set()
-        _CUSTOM_WILDCARD_SLOTS[norm_lang].update(wildcards)
-        _wildcard_slot_names.cache_clear()
-        wildcard_slot_names_sorted.cache_clear()
+    try:
+        canonical_language = normalize_language(language) if language else ""
+        norm_lang = _wildcard_language_key(canonical_language) if canonical_language else ""
+    except ValueError:
+        norm_lang = ""
+    registered = frozenset(wildcards) if wildcards else _EMPTY_WILDCARD_NAMES
+    _publish_registered_wildcards(norm_lang, registered)
 
 
-@lru_cache(maxsize=128)
+def _publish_registered_wildcards(norm_lang: str | None, registered: frozenset[str]) -> None:
+    """Publish an immutable wildcard registry snapshot under the writer lock.
+
+    A ``None`` language clears the complete registry. An empty set removes one
+    language. The published mapping and its values must remain immutable so
+    readers can safely retain a lock-free snapshot.
+    """
+    global _CUSTOM_WILDCARD_SLOTS
+    with _CUSTOM_WILDCARD_SLOTS_LOCK:
+        current = _CUSTOM_WILDCARD_SLOTS
+        if norm_lang is None:
+            if not current:
+                return
+            _CUSTOM_WILDCARD_SLOTS = _EMPTY_WILDCARD_REGISTRY
+            return
+        existing = current.get(norm_lang)
+        if existing == registered or (existing is None and not registered):
+            return
+        updated = dict(current)
+        if registered:
+            updated[norm_lang] = registered
+        else:
+            updated.pop(norm_lang, None)
+        _CUSTOM_WILDCARD_SLOTS = MappingProxyType(updated) if updated else _EMPTY_WILDCARD_REGISTRY
+
+
 def _wildcard_slot_names(language: str | None = None) -> frozenset[str]:
-    """Return all known wildcard slot names for the given language from home_assistant_intents.
+    """Return registered wildcard names without performing I/O.
 
     Wildcard slots (``"wildcard": true`` in HassIL lists) capture free-form
     user text, they have no predefined values.  Candidate templates expand
@@ -151,45 +186,26 @@ def _wildcard_slot_names(language: str | None = None) -> frozenset[str]:
     and the placeholder must be rehydrated from the original query before
     delegation.
 
-    The result is computed once and cached.
+    Intent sources and canonical language variants are resolved by the runtime's
+    executor build path. Keeping this query-time accessor memory-only guarantees
+    that it never consults the external intents corpus on Home Assistant's event
+    loop.
     """
-    names: set[str] = set()
+    registered_by_language = _CUSTOM_WILDCARD_SLOTS
     if language:
         try:
-            norm_lang = normalize_language(language)
+            norm_lang = _wildcard_language_key(language)
         except ValueError:
             norm_lang = ""
-        if norm_lang in _CUSTOM_WILDCARD_SLOTS:
-            names.update(_CUSTOM_WILDCARD_SLOTS[norm_lang])
-    else:
-        for custom_set in _CUSTOM_WILDCARD_SLOTS.values():
-            names.update(custom_set)
-
-    with contextlib.suppress(Exception):
-        import home_assistant_intents
-
-        languages = [language] if language else home_assistant_intents.get_languages()
-        for lang in languages:
-            try:
-                data = home_assistant_intents.get_intents(lang)
-            except Exception:
-                continue
-            if not isinstance(data, dict):
-                continue
-            lists = data.get("lists", {})
-            if not isinstance(lists, dict):
-                continue
-            for name, config in lists.items():
-                if isinstance(config, dict) and config.get("wildcard"):
-                    names.add(name)
-    return frozenset(names)
+        return registered_by_language.get(norm_lang, _EMPTY_WILDCARD_NAMES)
+    return frozenset(name for registered in registered_by_language.values() for name in registered)
 
 
 class _WildcardSlotNamesWrapper:
-    """Wrapper for wildcard_slot_names to support dynamic cache clearing."""
+    """Wrapper for wildcard_slot_names to support scoped registry clearing."""
 
     def __init__(self, func: Any) -> None:
-        """Initialize the wrapper with the cached function."""
+        """Initialize the wrapper with the registry accessor function."""
         self._func = func
 
     def __call__(self, language: str | None = None) -> frozenset[str]:
@@ -197,31 +213,34 @@ class _WildcardSlotNamesWrapper:
         return self._func(language)
 
     def cache_clear(self, language: str | None = None) -> None:
-        """Clear custom wildcards and delegation caches.
+        """Clear registered wildcards and the derived sorting cache.
 
         Passing a language removes only that language's custom wildcard
-        registrations while still clearing the shared LRU caches.
+        registrations.
         """
         if language is None:
-            _CUSTOM_WILDCARD_SLOTS.clear()
+            norm_lang = None
         else:
             try:
-                norm_lang = normalize_language(language)
+                norm_lang = _wildcard_language_key(language)
             except ValueError:
                 norm_lang = ""
-            _CUSTOM_WILDCARD_SLOTS.pop(norm_lang, None)
-        self._func.cache_clear()
-        wildcard_slot_names_sorted.cache_clear()
+        _publish_registered_wildcards(norm_lang, _EMPTY_WILDCARD_NAMES)
+        _sorted_wildcard_slot_names.cache_clear()
 
 
 wildcard_slot_names = _WildcardSlotNamesWrapper(_wildcard_slot_names)
 
 
 @lru_cache(maxsize=128)
-def wildcard_slot_names_sorted(language: str | None = None) -> tuple[str, ...]:
-    """Return all known wildcard slot names sorted by length descending (cached)."""
-    names = wildcard_slot_names(language)
+def _sorted_wildcard_slot_names(names: frozenset[str]) -> tuple[str, ...]:
+    """Return one immutable wildcard name set sorted by length descending."""
     return tuple(sorted(names, key=len, reverse=True))
+
+
+def wildcard_slot_names_sorted(language: str | None = None) -> tuple[str, ...]:
+    """Return all known wildcard slot names sorted by length descending."""
+    return _sorted_wildcard_slot_names(wildcard_slot_names(language))
 
 
 @lru_cache(maxsize=1024)
@@ -291,7 +310,5 @@ def to_output_value(val_float: float) -> int | float:
 def clear_utils_caches() -> None:
     """Clear all global LRU caches in utils module."""
     normalize_language.cache_clear()
-    _wildcard_slot_names.cache_clear()
-    wildcard_slot_names_sorted.cache_clear()
+    wildcard_slot_names.cache_clear()
     parse_float.cache_clear()
-    _CUSTOM_WILDCARD_SLOTS.clear()

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -31,6 +31,7 @@ from custom_components.assist_canonicalizer.conversation import (
 from custom_components.assist_canonicalizer.indexer import CanonicalIndex, build_index
 from custom_components.assist_canonicalizer.ranking import RankedCandidate, ScoreBreakdown
 from custom_components.assist_canonicalizer.runtime import CanonicalizerRuntime
+from custom_components.assist_canonicalizer.utils import wildcard_slot_names
 
 
 class MockConversationInput(ConversationInput):
@@ -1193,6 +1194,53 @@ async def test_async_validate_ranked_candidate_restores_chat_log(
 
         # Verify that mock_chat_log.content was restored (keeping only the original user message)
         assert mock_chat_log.content == [mock_user_message]
+
+
+@pytest.mark.asyncio
+async def test_async_validate_rehydrates_from_candidate_metadata_with_cold_cache() -> None:
+    """Rehydrate validation text without loading intents on the event loop."""
+    entry = MagicMock()
+    runtime = CanonicalizerRuntime()
+    entity = AssistCanonicalizerConversationEntity(entry, runtime)
+    entity.hass = MagicMock()
+    user_input = MockConversationInput("add milk to shopping list", "en")
+    candidate = Candidate(
+        text="add shopping_list_item to shopping list",
+        intent_name="HassShoppingListAddItem",
+        language="en",
+        metadata={
+            "sentence_template": "add {shopping_list_item} to shopping list",
+            "wildcard_slots": "shopping_list_item",
+        },
+    )
+    ranked = RankedCandidate(
+        candidate=candidate,
+        scores=ScoreBreakdown(1.0, 1.0, 1.0, 1.0, 1.0),
+    )
+    validation_result = MagicMock()
+    validation_result.response.error_code = None
+
+    wildcard_slot_names.cache_clear("en")
+    try:
+        with (
+            patch.object(
+                entity,
+                "_delegate_text",
+                AsyncMock(return_value=validation_result),
+            ) as delegate,
+            patch("home_assistant_intents.get_intents") as get_intents,
+        ):
+            result = await entity._async_validate_ranked_candidate(ranked, user_input)
+
+        assert result is validation_result
+        delegate.assert_awaited_once_with(
+            "add milk to shopping list",
+            user_input,
+            primary=True,
+        )
+        get_intents.assert_not_called()
+    finally:
+        wildcard_slot_names.cache_clear("en")
 
 
 class DummyChatLog:

--- a/tests/test_grammar_loader.py
+++ b/tests/test_grammar_loader.py
@@ -1,7 +1,7 @@
 """Tests for automatic conversation intent candidate loading."""
 
 import re
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from typing import Any
 from unittest.mock import patch
 
@@ -1135,6 +1135,28 @@ def test_build_candidates_preserve_wildcard_tag_shaped_sentence_literals() -> No
 class TestRehydrateWildcardText:
     """Tests for rehydrate_wildcard_text wildcard placeholder rehydration."""
 
+    @pytest.fixture(autouse=True)
+    def registered_wildcards(self) -> Iterator[None]:
+        """Register the wildcard corpus used by raw-text compatibility helpers."""
+        sources = {
+            "built_in": {
+                "lists": {
+                    "shopping_list_item": {"wildcard": True},
+                    "todo_list_item": {"wildcard": True},
+                    "timer_name": {"wildcard": True},
+                    "message": {"wildcard": True},
+                    "search_query": {"wildcard": True},
+                }
+            }
+        }
+        wildcard_slot_names.cache_clear()
+        for language in ("de", "en", "it", "nl", "vi"):
+            register_custom_wildcards_from_sources(language, sources)
+        try:
+            yield
+        finally:
+            wildcard_slot_names.cache_clear()
+
     def test_italian_shopping_list(self) -> None:
         """Rehydrate shopping_list_item from Italian query."""
         result = gl.rehydrate_wildcard_text(
@@ -1212,7 +1234,7 @@ class TestRehydrateWildcardText:
         assert result == "aggiungi tovaglioli alla Lista della Spesa"
 
     def test_wildcard_slot_names_populated(self) -> None:
-        """Verify wildcard_slot_names() returns known wildcard slots."""
+        """Verify wildcard_slot_names() returns registered wildcard slots."""
         mock_data = {
             "lists": {
                 "shopping_list_item": {"wildcard": True},
@@ -1222,15 +1244,9 @@ class TestRehydrateWildcardText:
                 "color": {"values": ["red", "blue"]},
             }
         }
-        with (
-            patch("home_assistant_intents.get_languages", return_value=["en"]),
-            patch("home_assistant_intents.get_intents", return_value=mock_data),
-        ):
-            wildcard_slot_names.cache_clear()
-            try:
-                self._test_wildcard_slot_names_populated()
-            finally:
-                wildcard_slot_names.cache_clear()
+        wildcard_slot_names.cache_clear()
+        register_custom_wildcards_from_sources("en", {"built_in": mock_data})
+        self._test_wildcard_slot_names_populated()
 
     def _test_wildcard_slot_names_populated(self) -> None:
         """Test that wildcard_slot_names() returns only wildcards, not entities."""

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -2246,7 +2246,11 @@ def test_rank_candidates_rehydrates_wildcard() -> None:
         text="broadcast message",
         intent_name="HassBroadcast",
         language="en",
-        metadata={"literal_text": "broadcast message"},
+        metadata={
+            "sentence_template": "broadcast {message}",
+            "wildcard_slots": "message",
+            "literal_text": "broadcast message",
+        },
     )
     assert candidate.has_wildcard
 
@@ -2416,7 +2420,11 @@ def test_wildcard_variants_analysis_removes_wildcard_and_deduplicates() -> None:
         text="message",
         intent_name="HassBroadcast",
         language="en",
-        metadata={"literal_text": "message|messages|broadcast message"},
+        metadata={
+            "sentence_template": "{message}",
+            "wildcard_slots": "message",
+            "literal_text": "message|messages|broadcast message",
+        },
     )
 
     variants, all_tokens = wildcard_variants_analysis(candidate)
@@ -2442,7 +2450,11 @@ def test_wildcard_variants_analysis_removes_embedded_structured_wildcard() -> No
         text="search_querypodcast",
         intent_name="HassMediaSearchAndPlay",
         language="de",
-        metadata={"literal_text": "spiel den search_querypodcast|spiel den podcast"},
+        metadata={
+            "sentence_template": "{search_query}podcast",
+            "wildcard_slots": "search_query",
+            "literal_text": "spiel den search_querypodcast|spiel den podcast",
+        },
     )
 
     variants, all_tokens = wildcard_variants_analysis(candidate)
@@ -2467,7 +2479,11 @@ def test_wildcard_variants_analysis_removes_embedded_single_word_wildcard() -> N
         text="urgentmessage",
         intent_name="HassBroadcast",
         language="en",
-        metadata={"literal_text": "broadcast urgentmessage|broadcast"},
+        metadata={
+            "sentence_template": "urgent{message}",
+            "wildcard_slots": "message",
+            "literal_text": "broadcast urgentmessage|broadcast",
+        },
     )
 
     variants, all_tokens = wildcard_variants_analysis(candidate)
@@ -2488,7 +2504,11 @@ def test_wildcard_variants_analysis_keeps_multilingual_word_containing_wildcard(
         text="messagerie",
         intent_name="HassBroadcast",
         language="fr",
-        metadata={"literal_text": "messagerie|diffuser message"},
+        metadata={
+            "sentence_template": "{message}",
+            "wildcard_slots": "message",
+            "literal_text": "messagerie|diffuser message",
+        },
     )
 
     variants, all_tokens = wildcard_variants_analysis(candidate)
@@ -2590,7 +2610,11 @@ def test_rank_candidates_wildcard_bypasses_prefilter() -> None:
         text="broadcast message",
         intent_name="HassBroadcast",
         language="en",
-        metadata={"literal_text": "broadcast message"},
+        metadata={
+            "sentence_template": "broadcast {message}",
+            "wildcard_slots": "message",
+            "literal_text": "broadcast message",
+        },
     )
     cand_1 = Candidate(
         text="turn on light",
@@ -2642,13 +2666,21 @@ def test_rank_candidates_applies_slot_preferences_tiebreaker() -> None:
         text="add shopping_list_item",
         intent_name="HassShoppingListAddItem",
         language="en",
-        metadata={"literal_text": "add"},
+        metadata={
+            "sentence_template": "add {shopping_list_item}",
+            "wildcard_slots": "shopping_list_item",
+            "literal_text": "add",
+        },
     )
     cand_todo = Candidate(
         text="add todo_list_item",
         intent_name="HassListAddItem",
         language="en",
-        metadata={"literal_text": "add"},
+        metadata={
+            "sentence_template": "add {todo_list_item}",
+            "wildcard_slots": "todo_list_item",
+            "literal_text": "add",
+        },
     )
 
     assert cand_shopping.has_wildcard
@@ -2682,19 +2714,31 @@ def test_wildcard_lookups_coverage() -> None:
         text="message",
         intent_name="HassBroadcast",
         language="en",
-        metadata={"literal_text": ""},
+        metadata={
+            "sentence_template": "{message}",
+            "wildcard_slots": "message",
+            "literal_text": "",
+        },
     )
     cand_var_len_0 = Candidate(
         text="broadcast message",
         intent_name="HassBroadcastVar0",
         language="en",
-        metadata={"literal_text": "|broadcast"},
+        metadata={
+            "sentence_template": "broadcast {message}",
+            "wildcard_slots": "message",
+            "literal_text": "|broadcast",
+        },
     )
     cand_normal = Candidate(
         text="broadcast message",
         intent_name="HassBroadcastNormal",
         language="en",
-        metadata={"literal_text": "broadcast"},
+        metadata={
+            "sentence_template": "broadcast {message}",
+            "wildcard_slots": "message",
+            "literal_text": "broadcast",
+        },
     )
 
     # 1. Exercise indexer post-init (with wildcard indices)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -23,6 +23,7 @@ from custom_components.assist_canonicalizer.const import (
     SERVICE_TEST_MATCH,
 )
 from custom_components.assist_canonicalizer.indexer import build_index
+from custom_components.assist_canonicalizer.ranking import RankedCandidate, ScoreBreakdown
 from custom_components.assist_canonicalizer.runtime import CanonicalizerRuntime
 from custom_components.assist_canonicalizer.services import (
     CLEAR_INDEX_SCHEMA,
@@ -41,6 +42,7 @@ from custom_components.assist_canonicalizer.services import (
     async_unload_services,
     validate_supported_language,
 )
+from custom_components.assist_canonicalizer.utils import wildcard_slot_names
 
 _EXPECTED_SERVICE_SCHEMAS = {
     SERVICE_TEST_MATCH: TEST_MATCH_SCHEMA,
@@ -167,6 +169,44 @@ async def test_handle_test_match_entry_none_and_data_fallback() -> None:
     hass_data = MockHass(runtime, entry=entry_data)
     result_data = await _handle_test_match(hass_data, cast(ServiceCall, call))
     assert result_data["accepted"] is True
+
+
+@pytest.mark.asyncio
+async def test_handle_test_match_rehydrates_from_candidate_metadata_with_cold_cache() -> None:
+    """Rehydrate service results without loading intents on the event loop."""
+    runtime = CanonicalizerRuntime()
+    candidate = Candidate(
+        text="add shopping_list_item to shopping list",
+        intent_name="HassShoppingListAddItem",
+        language="en",
+        metadata={
+            "sentence_template": "add {shopping_list_item} to shopping list",
+            "wildcard_slots": "shopping_list_item",
+        },
+    )
+    runtime.set_index(build_index("en", [candidate]))
+    ranked = RankedCandidate(
+        candidate=candidate,
+        scores=ScoreBreakdown(1.0, 1.0, 1.0, 1.0, 1.0),
+    )
+    hass = MockHass(runtime)
+    call = MockServiceCall({"text": "add milk to shopping list", "language": "en"})
+
+    wildcard_slot_names.cache_clear("en")
+    with (
+        patch.object(
+            CanonicalizerRuntime,
+            "rank_with_dynamic_candidates",
+            return_value=(ranked,),
+        ),
+        patch("home_assistant_intents.get_intents") as get_intents,
+    ):
+        result = await _handle_test_match(hass, cast(ServiceCall, call))
+
+    assert result["selected_candidate"]["text"] == "add milk to shopping list"
+    assert result["top_candidates"][0]["text"] == "add milk to shopping list"
+    get_intents.assert_not_called()
+    wildcard_slot_names.cache_clear("en")
 
 
 @pytest.mark.asyncio

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -6,7 +6,7 @@ atypical input conditions, missing dependencies, and external errors.
 
 from __future__ import annotations
 
-import sys
+from threading import Event, Thread, current_thread
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import custom_components.assist_canonicalizer.config_flow as cf
+import custom_components.assist_canonicalizer.utils as utils
 from custom_components.assist_canonicalizer.bm25 import BM25Index
 from custom_components.assist_canonicalizer.candidate import (
     Candidate,
@@ -61,14 +62,26 @@ def test_normalize_language_stability() -> None:
         normalize_language("   ")
 
 
-def test_wildcard_slot_names_import_error_stability() -> None:
-    """Verify that wildcard_slot_names handles missing home_assistant_intents dependency."""
-    with patch.dict(sys.modules, {"home_assistant_intents": None}):
-        wildcard_slot_names.cache_clear()
-        try:
+def test_wildcard_slot_names_is_memory_only() -> None:
+    """Never load the external intents corpus from the synchronous accessor."""
+    wildcard_slot_names.cache_clear()
+    try:
+        register_custom_wildcards_from_sources(
+            "en",
+            {"built_in": {"lists": {"message": {"wildcard": True}}}},
+        )
+        normalize_language.cache_clear()
+        with (
+            patch("home_assistant_intents.get_languages") as get_languages,
+            patch("home_assistant_intents.get_intents") as get_intents,
+        ):
+            assert wildcard_slot_names("en") == frozenset({"message"})
+            wildcard_slot_names.cache_clear("en")
             assert wildcard_slot_names("en") == frozenset()
-        finally:
-            wildcard_slot_names.cache_clear()
+        get_languages.assert_not_called()
+        get_intents.assert_not_called()
+    finally:
+        wildcard_slot_names.cache_clear()
 
 
 def test_wildcard_slot_names_cache_clear_can_scope_custom_language() -> None:
@@ -76,7 +89,7 @@ def test_wildcard_slot_names_cache_clear_can_scope_custom_language() -> None:
     wildcard_slot_names.cache_clear()
     try:
         register_custom_wildcards_from_sources(
-            "xx-one",
+            "XX_one",
             {"custom": {"lists": {"one_custom_wildcard": {"wildcard": True}}}},
         )
         register_custom_wildcards_from_sources(
@@ -84,10 +97,10 @@ def test_wildcard_slot_names_cache_clear_can_scope_custom_language() -> None:
             {"custom": {"lists": {"two_custom_wildcard": {"wildcard": True}}}},
         )
 
-        assert "one_custom_wildcard" in wildcard_slot_names("xx-one")
+        assert "one_custom_wildcard" in wildcard_slot_names("xx_one")
         assert "two_custom_wildcard" in wildcard_slot_names("xx-two")
 
-        wildcard_slot_names.cache_clear("xx-one")
+        wildcard_slot_names.cache_clear("XX-ONE")
 
         assert "one_custom_wildcard" not in wildcard_slot_names("xx-one")
         assert "two_custom_wildcard" in wildcard_slot_names("xx-two")
@@ -95,51 +108,80 @@ def test_wildcard_slot_names_cache_clear_can_scope_custom_language() -> None:
         wildcard_slot_names.cache_clear()
 
 
-def test_wildcard_slot_names_exceptions_and_types_stability() -> None:
-    """Verify that wildcard_slot_names isolates external intents parsing errors."""
-    pytest.importorskip("home_assistant_intents")
-    import home_assistant_intents as intents_module
-
-    # Exception raised during intents parsing
+def test_wildcard_slot_names_replaces_stale_and_malformed_sources() -> None:
+    """Keep the in-memory registry aligned with the latest loaded sources."""
     wildcard_slot_names.cache_clear()
-    with patch.object(intents_module, "get_intents", side_effect=Exception("mock error")):
-        try:
-            assert wildcard_slot_names("en") == frozenset()
-        finally:
-            wildcard_slot_names.cache_clear()
+    try:
+        register_custom_wildcards_from_sources(
+            "en",
+            {"custom": {"lists": {"old_wildcard": {"wildcard": True}}}},
+        )
+        assert wildcard_slot_names_sorted("en") == ("old_wildcard",)
 
-    # Returned intents data is not a dict
+        register_custom_wildcards_from_sources(
+            "en",
+            {"custom": {"lists": []}},
+        )
+        assert wildcard_slot_names("en") == frozenset()
+        assert wildcard_slot_names_sorted("en") == ()
+
+        register_custom_wildcards_from_sources("en", {})
+        assert wildcard_slot_names("en") == frozenset()
+    finally:
+        wildcard_slot_names.cache_clear()
+
+
+def test_wildcard_slot_names_concurrent_registration_cannot_cache_stale_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep subsequent reads current when registration overlaps an in-flight read."""
     wildcard_slot_names.cache_clear()
-    with patch.object(intents_module, "get_intents", return_value="not-a-dict"):
-        try:
-            assert wildcard_slot_names("en") == frozenset()
-        finally:
-            wildcard_slot_names.cache_clear()
+    reader_entered = Event()
+    release_reader = Event()
+    observed: list[frozenset[str]] = []
+    reader_name = "wildcard-registry-reader"
+    original_wildcard_language_key = utils._wildcard_language_key
+    reader: Thread | None = None
 
-    # Returned lists structure is not a dict
-    wildcard_slot_names.cache_clear()
-    with patch.object(intents_module, "get_intents", return_value={"lists": []}):
-        try:
-            assert wildcard_slot_names("en") == frozenset()
-        finally:
-            wildcard_slot_names.cache_clear()
+    def controlled_wildcard_language_key(language: str) -> str:
+        """Pause only the reader after it has entered the registry accessor."""
+        if current_thread().name == reader_name:
+            reader_entered.set()
+            if not release_reader.wait(timeout=5):
+                raise TimeoutError("Wildcard registry reader was not released")
+        return original_wildcard_language_key(language)
 
-    # Exception in outer try block
-    wildcard_slot_names.cache_clear()
-    with patch.object(intents_module, "get_languages", side_effect=ValueError("bad")):
-        try:
-            assert wildcard_slot_names(None) == frozenset()
-        finally:
-            wildcard_slot_names.cache_clear()
+    try:
+        register_custom_wildcards_from_sources(
+            "en",
+            {"custom": {"lists": {"old_wildcard": {"wildcard": True}}}},
+        )
+        monkeypatch.setattr(utils, "_wildcard_language_key", controlled_wildcard_language_key)
+        reader = Thread(
+            target=lambda: observed.append(wildcard_slot_names("en")),
+            name=reader_name,
+        )
+        reader.start()
+        assert reader_entered.wait(timeout=5)
 
-    # Test sorted wrapper handles outer exceptions
-    wildcard_slot_names_sorted.cache_clear()
-    with patch.object(intents_module, "get_languages", side_effect=ValueError("bad")):
-        try:
-            assert wildcard_slot_names_sorted(None) == ()
-        finally:
-            wildcard_slot_names.cache_clear()
-            wildcard_slot_names_sorted.cache_clear()
+        register_custom_wildcards_from_sources(
+            "en",
+            {"custom": {"lists": {"new_wildcard": {"wildcard": True}}}},
+        )
+        release_reader.set()
+        reader.join(timeout=5)
+
+        assert not reader.is_alive()
+        assert observed in (
+            [frozenset({"old_wildcard"})],
+            [frozenset({"new_wildcard"})],
+        )
+        assert wildcard_slot_names("en") == frozenset({"new_wildcard"})
+    finally:
+        release_reader.set()
+        if reader is not None:
+            reader.join(timeout=5)
+        wildcard_slot_names.cache_clear()
 
 
 def test_candidate_literal_variants_recovers_from_corrupt_metadata() -> None:
@@ -301,7 +343,17 @@ def test_ranking_stability() -> None:
 def test_prefilter_wildcard_candidates_stability() -> None:
     """Verify prefiltering candidate selector defaults cleanly on empty lookups."""
     # wildcard_variant_analyses is None when wildcard_always_passes is active
-    cands = [Candidate(text="add shopping_list_item", intent_name="dummy", language="en")]
+    cands = [
+        Candidate(
+            text="add shopping_list_item",
+            intent_name="dummy",
+            language="en",
+            metadata={
+                "sentence_template": "add {shopping_list_item}",
+                "wildcard_slots": "shopping_list_item",
+            },
+        )
+    ]
     res = _prefilter_wildcard_candidates(
         candidates=cands,
         query_tokens=frozenset({"add"}),
@@ -327,7 +379,11 @@ def test_prefilter_wildcard_candidates_stability() -> None:
         text="spiel den search_querypodcast",
         intent_name="dummy",
         language="de",
-        metadata={"literal_text": "spiel|den"},
+        metadata={
+            "sentence_template": "spiel den {search_query}podcast",
+            "wildcard_slots": "search_query",
+            "literal_text": "spiel|den",
+        },
     )
     res_disjoint = _prefilter_wildcard_candidates(
         candidates=[cand_wc],

--- a/uv.lock
+++ b/uv.lock
@@ -538,30 +538,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.48"
+version = "1.43.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/bc/6b285efc5a7ebb27762f20d3fa2d78b8ff86d069d8eef343876d03466273/boto3-1.43.48.tar.gz", hash = "sha256:0077b3f38d47034f53ec68f3976f9d9beeabcc0faee7b1d6fa6b666e0852eca7", size = 112674, upload-time = "2026-07-14T19:29:57.742Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/2c/e9a853d4ca66f7ce1bf820674bcd9e6dd1934c27a4c545c67d3b69338d9b/boto3-1.43.49.tar.gz", hash = "sha256:e58e0704805f720b94e40a56588eadd6da05d3693bde78b573116b11ae56710f", size = 112755, upload-time = "2026-07-15T19:32:17.777Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/ec/3e4bff3d696121631174471505a7669d9d22c183991b4dcc245101603cec/boto3-1.43.48-py3-none-any.whl", hash = "sha256:5866f8a99877342db130e7236a8048b63d3d8e74c46d4ef101771350019bd3df", size = 140032, upload-time = "2026-07-14T19:29:55.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/08/73efb432f9da880deb91eded8ed41d23f03ec7ac47af9b8ecf884f276876/boto3-1.43.49-py3-none-any.whl", hash = "sha256:2b31ab1a0eb1cee01d0363b8ee5e68b45dff2c8f99e7b53aca11c9f7b591a794", size = 140033, upload-time = "2026-07-15T19:32:16.483Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.48"
+version = "1.43.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/69/76c5576654c0982351a821c544042ccd7a25a060776453a3c15e0486e47e/botocore-1.43.48.tar.gz", hash = "sha256:4f60c1072fb529610359cdb6df92c59615d739df3b0a124091d3bbd28f7ea00c", size = 15700978, upload-time = "2026-07-14T19:29:45.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2c/da2832f435371cd6c95b64325f981b3babe71e4aa4a71798b00ce2073100/botocore-1.43.49.tar.gz", hash = "sha256:7de02863c95b8008b1400c92a1a00996f25ad38944c07f7b620949f8798d1fdf", size = 15708260, upload-time = "2026-07-15T19:32:08.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/b0/28d40443ed912260d55cf7a5d377378fc43e384627fd57b632472cbea7bf/botocore-1.43.48-py3-none-any.whl", hash = "sha256:cc9b4e925c1913d662194507f4f9b37aa744dcd2361af31c013672eafe824490", size = 15385380, upload-time = "2026-07-14T19:29:41.826Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/21/29bf66d513bca978c9506060c44eaf6df3210bd7773bf94beaed1ce56d18/botocore-1.43.49-py3-none-any.whl", hash = "sha256:16b6838ac2fbbab85fb265c1f2e37906527aca07f461b1d293d3f8ab82f992dc", size = 15393460, upload-time = "2026-07-15T19:32:05.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Keep wildcard slot name resolution fully in-memory and non-blocking, and route wildcard text rehydration through the new metadata-driven helper across conversation and services.

New Features:
- Add immutable, lock-guarded wildcard registry snapshots and a scoped clearing API to support concurrent readers and dynamic wildcard registration.
- Introduce metadata-driven wildcard rehydration usage in conversation validation and test-match services so user-facing text is reconstructed from candidate metadata instead of raw templates.

Enhancements:
- Refactor wildcard slot name access to remove on-demand loading from external intents, relying solely on pre-registered in-memory sources.
- Adjust runtime index build to register wildcard names without pre-warming caches, aligning with the new non-blocking accessor design.
- Expand and update tests to cover wildcard registry lifecycle, concurrent registration behavior, and cold-cache rehydration paths, including richer candidate metadata for wildcard handling.
- Update grammar loader tests to register wildcard corpora via the new registration API and to assert behavior against the in-memory wildcard registry.

Tests:
- Add async tests ensuring conversation validation and services rehydrate wildcard text from candidate metadata without triggering intents loading on the event loop.
- Add stability and grammar-loader tests verifying wildcard registry replacement, snapshot reuse, scoped clearing, and correct wildcard name exposure from registered sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wildcard text rehydration for both candidate validation and ranked response display, including cold-cache scenarios.
  * Prevented wildcard display generation from triggering intent loading during event-loop execution.
* **Reliability**
  * Updated wildcard-slot registry to use immutable snapshot reads with atomic updates for concurrency safety.
  * Refined wildcard cache clearing and registry publication to ensure scoped clears don’t remove other languages’ registrations.
  * Reduced prewarming behavior during runtime snapshot creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->