### PR TITLE
Align HassIL shortcut behavior with Assist pipeline configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ People do not always phrase the same request in the same way. Word order, filler
 
 ## How It Works
 
-Assist Canonicalizer gives Home Assistant's built-in HassIL agent the first chance to handle each request. Canonicalization begins only if HassIL cannot handle the original text:
+Home Assistant gives its built-in HassIL agent the first chance when the Assist pipeline has `prefer_local_intents` enabled. When that option is disabled, Assist Canonicalizer supplies the equivalent HassIL-first shortcut. Canonicalization begins only if HassIL cannot handle the original text:
 
 ```mermaid
 flowchart TD
@@ -127,7 +127,7 @@ flowchart TD
     K -->|Failure| G
 ```
 
-1. **HassIL First**: The request is sent unchanged to Home Assistant's built-in conversation agent before any canonicalization. The Assist pipeline may already have tried a subset of local intents, but whenever Assist Canonicalizer is invoked, it still sends the complete original request to HassIL regardless of the pipeline setting. If HassIL succeeds, its result is returned immediately and the remaining steps are skipped.
+1. **HassIL First**: With `prefer_local_intents` enabled, Home Assistant tries HassIL before falling back to Assist Canonicalizer. With it disabled, the pipeline delegates directly to Assist Canonicalizer, which sends the unchanged request to HassIL as a shortcut. The integration skips its shortcut when Home Assistant has already performed the local-intent pass. If HassIL succeeds, its result is returned immediately and the remaining steps are skipped.
 
 2. **Text Normalization**: The input is NFKC-normalized, casefolded, stripped of punctuation, and collapsed to a consistent whitespace form. The same process is applied to the input and candidate sentences.
 
@@ -158,7 +158,7 @@ flowchart TD
 
 ## Benchmark Results
 
-The managed-live benchmark runs every query twice against the same Home Assistant fixture: once directly through HassIL and once through Assist Canonicalizer's direct path. To mirror production routing, the reported Assist Canonicalizer result uses the HassIL outcome when it is correct and uses the direct canonicalizer outcome only when HassIL fails. Both runs are evaluated against executable controls for intent, slot, and target resolution.
+The managed-live benchmark runs every query twice against the same Home Assistant fixture: once directly through HassIL and once through Assist Canonicalizer's direct path. To mirror production routing, the reported Assist Canonicalizer result uses the HassIL outcome when it is correct and uses the direct canonicalizer outcome only when HassIL fails. This models both HassIL-first routes: Home Assistant's local-intent pass when `prefer_local_intents` is enabled and Assist Canonicalizer's shortcut when it is disabled. Both runs are evaluated against executable controls for intent, slot, and target resolution.
 
 ### Overall Results
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -101,7 +101,7 @@ Trong thực tế, cùng một yêu cầu có thể được diễn đạt theo 
 
 ## Cách hoạt động
 
-Assist Canonicalizer luôn để tác nhân HassIL tích hợp sẵn của Home Assistant thử xử lý yêu cầu trước. Quá trình chuẩn hóa chỉ bắt đầu khi HassIL không xử lý được văn bản gốc:
+Khi pipeline Assist bật `prefer_local_intents`, Home Assistant để tác nhân HassIL tích hợp sẵn thử xử lý yêu cầu trước. Khi tùy chọn này bị tắt, Assist Canonicalizer cung cấp shortcut ưu tiên HassIL tương đương. Quá trình chuẩn hóa chỉ bắt đầu khi HassIL không xử lý được văn bản gốc:
 
 ```mermaid
 flowchart TD
@@ -127,7 +127,7 @@ flowchart TD
     K -->|Thất bại| G
 ```
 
-1. **Ưu tiên HassIL**: Yêu cầu được giữ nguyên và gửi đến tác nhân hội thoại tích hợp sẵn của Home Assistant trước khi chuẩn hóa. Luồng Assist có thể đã thử một số ý định cục bộ, nhưng mỗi khi được gọi, Assist Canonicalizer vẫn gửi nguyên văn yêu cầu đến HassIL bất kể cài đặt của luồng. Nếu HassIL xử lý thành công, kết quả được trả về ngay và các bước còn lại được bỏ qua.
+1. **Ưu tiên HassIL**: Khi bật `prefer_local_intents`, Home Assistant thử HassIL trước khi chuyển sang Assist Canonicalizer. Khi tắt tùy chọn này, pipeline chuyển thẳng đến Assist Canonicalizer và bộ tích hợp gửi nguyên văn yêu cầu đến HassIL dưới dạng shortcut. Bộ tích hợp bỏ qua shortcut khi Home Assistant đã thực hiện lượt nhận diện ý định cục bộ. Nếu HassIL xử lý thành công, kết quả được trả về ngay và các bước còn lại được bỏ qua.
 
 2. **Chuẩn hóa văn bản (Text Normalization)**: Chuẩn hóa ký tự theo NFKC, chuyển chữ hoa thành chữ thường theo Unicode, loại bỏ dấu câu và thu gọn khoảng trắng. Quy trình giống nhau được áp dụng cho câu lệnh đầu vào và các câu ứng viên.
 
@@ -158,7 +158,7 @@ flowchart TD
 
 ## Kết quả đo kiểm
 
-Benchmark `managed_live` chạy mỗi truy vấn hai lần trên cùng một môi trường Home Assistant: một lần trực tiếp qua HassIL và một lần qua đường dẫn trực tiếp của Assist Canonicalizer. Để phản ánh đúng thứ tự xử lý thực tế, kết quả Assist Canonicalizer được tính theo kết quả HassIL khi HassIL xử lý chính xác; chỉ khi HassIL thất bại mới dùng kết quả của đường dẫn chuẩn hóa. Cả hai lượt chạy đều được đối chiếu với dữ liệu kiểm soát có thể thực thi để đánh giá ý định, tham số và mục tiêu.
+Benchmark `managed_live` chạy mỗi truy vấn hai lần trên cùng một môi trường Home Assistant: một lần trực tiếp qua HassIL và một lần qua đường dẫn trực tiếp của Assist Canonicalizer. Để phản ánh đúng thứ tự xử lý thực tế, kết quả Assist Canonicalizer được tính theo kết quả HassIL khi HassIL xử lý chính xác; chỉ khi HassIL thất bại mới dùng kết quả của đường dẫn chuẩn hóa. Cách tính này mô phỏng cả hai đường dẫn ưu tiên HassIL: lượt nhận diện ý định cục bộ của Home Assistant khi bật `prefer_local_intents` và shortcut của Assist Canonicalizer khi tắt tùy chọn này. Cả hai lượt chạy đều được đối chiếu với dữ liệu kiểm soát có thể thực thi để đánh giá ý định, tham số và mục tiêu.
 
 ### Kết quả tổng quan
 

--- a/custom_components/assist_canonicalizer/conversation.py
+++ b/custom_components/assist_canonicalizer/conversation.py
@@ -227,26 +227,18 @@ class AssistCanonicalizerConversationEntity(
     async def _async_try_assist_pipeline_shortcut(
         self, user_input: ConversationInput
     ) -> ConversationResult | None:
-        """Guarantee HassIL-first routing for requests from an active Assist pipeline.
+        """Try HassIL when the active Assist pipeline has not already done so.
 
-        Home Assistant's pipeline may run a local-intent pre-pass when
-        ``prefer_local_intents`` is enabled. For control-capable conversation agents,
-        that pre-pass is filtered and is therefore not equivalent to sending the
-        original text through the complete built-in conversation agent. When
-        ``prefer_local_intents`` is disabled, the pipeline delegates directly to this
-        entity without a local-intent pre-pass.
+        With ``prefer_local_intents`` enabled, Home Assistant tries local intents
+        before falling back to this conversation agent, so repeating that work here
+        would duplicate the pipeline's HassIL-first routing. When the option is
+        disabled, the pipeline delegates directly to this entity and this shortcut
+        supplies the equivalent HassIL-first behavior.
 
-        Consequently, reaching this entity never proves that full HassIL recognition
-        has already failed. Once the request is correlated with an active pipeline run,
-        always delegate the untouched text to the primary Home Assistant agent before
-        ranking, regardless of ``prefer_local_intents``. Returning a successful result
-        here is the regression-protection invariant: canonicalization cannot replace a
-        command that HassIL already handles.
-
-        Requests made directly to the conversation entity have no active pipeline run
-        and intentionally skip this pipeline-specific shortcut. A shortcut error or
-        rejected HassIL result is non-terminal: chat-log state is restored, then
-        canonical matching and the configured fallback agent remain available.
+        Direct calls without an active pipeline run skip this pipeline-specific
+        shortcut. A shortcut error or rejected HassIL result is non-terminal:
+        chat-log state is restored, then canonical matching and the configured
+        fallback agent remain available.
         """
         chat_log = self._get_active_chat_log()
         old_len = len(chat_log.content) if chat_log is not None else None
@@ -269,7 +261,7 @@ class AssistCanonicalizerConversationEntity(
                     if current_pipeline:
                         break
 
-            if current_pipeline is None:
+            if current_pipeline is None or getattr(current_pipeline, "prefer_local_intents", False):
                 return None
 
             shortcut_result = await self._delegate_with_capture(
@@ -328,11 +320,11 @@ class AssistCanonicalizerConversationEntity(
     async def _async_process_with_runtime(
         self, user_input: ConversationInput
     ) -> ConversationResult:
-        """Apply HassIL-first protection, canonicalization, and raw fallback in order.
+        """Apply pipeline-aware HassIL protection, canonicalization, and fallback.
 
-        The shortcut owns the user-visible no-regression boundary. Ranking is reached
-        only after untouched input is rejected by HassIL (or when the entity is called
-        outside an active Assist pipeline and the pipeline shortcut is unavailable).
+        Home Assistant owns the HassIL-first boundary when ``prefer_local_intents`` is
+        enabled; otherwise the shortcut supplies it before ranking. Direct entity
+        calls have no pipeline-level protection and intentionally skip the shortcut.
         Every unsuccessful local path still delegates the original text to the
         configured fallback agent.
         """

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1709,17 +1709,19 @@ async def test_conversation_delegate_and_fallback_agent_logic() -> None:
     await entity.async_prepare(None)
 
 
+@pytest.mark.parametrize(
+    ("prefer_local_intents", "uses_shortcut"),
+    [(False, True), (True, False)],
+    ids=["disabled-uses-shortcut", "enabled-skips-shortcut"],
+)
 @pytest.mark.asyncio
-async def test_async_process_prefer_local_intents_shortcut(
+async def test_assist_pipeline_shortcut_respects_prefer_local_intents(
     monkeypatch: pytest.MonkeyPatch,
+    prefer_local_intents: bool,
+    uses_shortcut: bool,
 ) -> None:
-    """Test prefer_local_intents shortcut behavior when it is False."""
+    """Use the HassIL shortcut only when Home Assistant has not already done so."""
     _mock_assist_pipeline_const(monkeypatch)
-
-    class DummyPipeline:
-        """Dummy pipeline class for testing."""
-
-        prefer_local_intents = False
 
     entry = MagicMock(entry_id="test-entry")
     entry.options = {}
@@ -1729,67 +1731,26 @@ async def test_async_process_prefer_local_intents_shortcut(
     entity.hass = MagicMock()
     user_input = MockConversationInput("tắt đèn bếp", "vi")
     entity.hass.data = {
-        "assist_pipeline": _active_pipeline_data(user_input.context, DummyPipeline())
-    }
-    validation_ok_res = MagicMock()
-    validation_ok_res.response.error_code = None
-
-    with (
-        patch.object(
-            entity, "_delegate_text", AsyncMock(return_value=validation_ok_res)
-        ) as mock_delegate,
-        patch.object(CanonicalizerRuntime, "rank_with_dynamic_candidates") as mock_rank,
-    ):
-        res = await entity.async_process(user_input)
-        assert res is validation_ok_res
-        mock_delegate.assert_called_once_with(
-            "tắt đèn bếp",
-            user_input,
-            primary=True,
+        "assist_pipeline": _active_pipeline_data(
+            user_input.context,
+            SimpleNamespace(prefer_local_intents=prefer_local_intents),
         )
-        mock_rank.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_async_process_prefer_local_intents_true_uses_shortcut(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Keep HassIL first when Home Assistant filters its local-intent pre-pass."""
-    _mock_assist_pipeline_const(monkeypatch)
-
-    class DummyPipeline:
-        """Dummy pipeline class for testing."""
-
-        prefer_local_intents = True
-
-    entry = MagicMock(entry_id="test-entry")
-    entry.options = {}
-    entry.data = {}
-    runtime = CanonicalizerRuntime()
-    entity = AssistCanonicalizerConversationEntity(entry, runtime)
-    entity.hass = MagicMock()
-
-    user_input = MockConversationInput("tắt đèn bếp", "vi")
-    entity.hass.data = {
-        "assist_pipeline": _active_pipeline_data(user_input.context, DummyPipeline())
     }
-    validation_ok_res = MagicMock()
-    validation_ok_res.response.error_code = None
+    shortcut_result = MagicMock()
 
-    with (
-        patch.object(
-            entity, "_delegate_text", AsyncMock(return_value=validation_ok_res)
-        ) as mock_delegate,
-        patch.object(CanonicalizerRuntime, "rank_with_dynamic_candidates") as mock_rank,
-    ):
-        res = await entity.async_process(user_input)
-        assert res is validation_ok_res
-        mock_delegate.assert_called_once_with(
-            "tắt đèn bếp",
-            user_input,
-            primary=True,
-        )
-        mock_rank.assert_not_called()
+    with patch.object(
+        entity,
+        "_delegate_with_capture",
+        AsyncMock(return_value=shortcut_result),
+    ) as mock_shortcut:
+        result = await entity._async_try_assist_pipeline_shortcut(user_input)
+
+    if uses_shortcut:
+        assert result is shortcut_result
+        mock_shortcut.assert_awaited_once_with(user_input.text, user_input, None, None)
+    else:
+        assert result is None
+        mock_shortcut.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -575,30 +575,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.57"
+version = "1.43.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/30/324319a914752e4021358ccf8252c04364eb8358f9d41d9c3f021959b363/boto3-1.43.57.tar.gz", hash = "sha256:549c95e45f9b04cf0c69727632dbdda23b84dcd3d0ed7981c6aaff72ef9cb5af", size = 112690, upload-time = "2026-07-27T19:31:09.32Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/95/bd6276870084c9c1a94e17d1dc73b2de275e59bd7a0ad8bfff0a1598cec4/boto3-1.43.58.tar.gz", hash = "sha256:12871fb50c383f1b9aa4ed6dd386ba689062baef730552e79d5a9cd782b53058", size = 112685, upload-time = "2026-07-28T19:35:09.336Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/a4/2c4ee25556a997a81ea01073962cf8351da3707412c584d053b3861d09e8/boto3-1.43.57-py3-none-any.whl", hash = "sha256:115ed9cac409d9b57e2437b52fdb4286660d12a2bd44a0f48d530e68623d09a7", size = 140028, upload-time = "2026-07-27T19:31:07.226Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/85/b0709066efb4ce7b86aba4092c739ad0e458be9d62cf32550fc4c130c93f/boto3-1.43.58-py3-none-any.whl", hash = "sha256:ce1a20cbcfaa1d0b3c8f568e2b6c7fbd34b842ea00e729d49a4b4de522828db9", size = 140026, upload-time = "2026-07-28T19:35:06.993Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.57"
+version = "1.43.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/92/1f8a454cf90bcb0c0e32a25817441cb7f3702fdd76710d7018abad12a2fc/botocore-1.43.57.tar.gz", hash = "sha256:001a5653bebc03b862bde2da63bad4adb0b30072a3f247aba4daae5aa097b546", size = 15739550, upload-time = "2026-07-27T19:30:57.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/64/5cd46a7e72b0647e6d78fc8da016259ad66b9ae0818f4c5d629c75e7ca49/botocore-1.43.58.tar.gz", hash = "sha256:e110ca53f65c128fe98df4d6d36a459b1db17c6114671c8a18becf151bf20909", size = 15742412, upload-time = "2026-07-28T19:34:57.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/7a/1cfe9c296df0fa6e0143c8622b10f21fa8fb9cce25450e9a8e5cf6523e4b/botocore-1.43.57-py3-none-any.whl", hash = "sha256:319c6d79f66c3f3f2b538f7dcdc90e410a15a7bfced1db06479134947e629482", size = 15424433, upload-time = "2026-07-27T19:30:55.08Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/82/6f8fbbea47b773734ba0199643d2d851e5c2f75bc3699fe99db8af344d96/botocore-1.43.58-py3-none-any.whl", hash = "sha256:f516159f0732da8249206163ccea3bd1f82ad2a9d184fe6ed447e1abdba4330e", size = 15426503, upload-time = "2026-07-28T19:34:53.508Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Align Assist Canonicalizer’s HassIL shortcut behavior with the Assist pipeline’s `prefer_local_intents` option and update tests and docs to reflect the new pipeline-aware routing.

Documentation:
- Clarify in English and Vietnamese documentation how HassIL-first routing depends on the Assist pipeline’s `prefer_local_intents` setting and how the shortcut behaves in each mode.

Tests:
- Consolidate and parametrize tests to verify the HassIL shortcut runs only when `prefer_local_intents` is disabled.