### PR TITLE
Refactor constants into named StrEnum groups

### DIFF
--- a/custom_components/assist_canonicalizer/config_flow.py
+++ b/custom_components/assist_canonicalizer/config_flow.py
@@ -24,12 +24,6 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import (
-    CONF_ENABLE_HOTWORD,
-    CONF_FALLBACK_AGENT_ID,
-    CONF_HOTWORD,
-    CONF_HOTWORD_MIN_CONFIDENCE,
-    CONF_MIN_CONFIDENCE,
-    CONF_MIN_MARGIN,
     DEFAULT_ENABLE_HOTWORD,
     DEFAULT_HOTWORD,
     DEFAULT_HOTWORD_MIN_CONFIDENCE,
@@ -37,6 +31,7 @@ from .const import (
     DEFAULT_MIN_MARGIN,
     DOMAIN,
     NAME,
+    ConfigKey,
 )
 from .utils import normalize_hotword_list
 
@@ -96,15 +91,15 @@ def _config_schema(
 ) -> vol.Schema:
     """Return config schema for fallback agent and confidence options."""
     defaults = defaults or {}
-    fallback_default = str(defaults.get(CONF_FALLBACK_AGENT_ID, ""))
+    fallback_default = str(defaults.get(ConfigKey.FALLBACK_AGENT_ID, ""))
     if not fallback_default and HOME_ASSISTANT_AGENT:
         fallback_default = HOME_ASSISTANT_AGENT
-    raw_hotword = defaults.get(CONF_HOTWORD, DEFAULT_HOTWORD)
+    raw_hotword = defaults.get(ConfigKey.HOTWORD, DEFAULT_HOTWORD)
     hotword_default = normalize_hotword_list(raw_hotword)
     return vol.Schema(
         {
             vol.Optional(
-                CONF_FALLBACK_AGENT_ID,
+                ConfigKey.FALLBACK_AGENT_ID.value,
                 default=fallback_default,
             ): SelectSelector(
                 SelectSelectorConfig(
@@ -118,8 +113,8 @@ def _config_schema(
                 )
             ),
             vol.Optional(
-                CONF_MIN_CONFIDENCE,
-                default=defaults.get(CONF_MIN_CONFIDENCE, DEFAULT_MIN_CONFIDENCE),
+                ConfigKey.MIN_CONFIDENCE.value,
+                default=defaults.get(ConfigKey.MIN_CONFIDENCE, DEFAULT_MIN_CONFIDENCE),
             ): NumberSelector(
                 NumberSelectorConfig(
                     min=0.0,
@@ -129,8 +124,8 @@ def _config_schema(
                 )
             ),
             vol.Optional(
-                CONF_MIN_MARGIN,
-                default=defaults.get(CONF_MIN_MARGIN, DEFAULT_MIN_MARGIN),
+                ConfigKey.MIN_MARGIN.value,
+                default=defaults.get(ConfigKey.MIN_MARGIN, DEFAULT_MIN_MARGIN),
             ): NumberSelector(
                 NumberSelectorConfig(
                     min=0.0,
@@ -140,17 +135,17 @@ def _config_schema(
                 )
             ),
             vol.Optional(
-                CONF_ENABLE_HOTWORD,
-                default=defaults.get(CONF_ENABLE_HOTWORD, DEFAULT_ENABLE_HOTWORD),
+                ConfigKey.ENABLE_HOTWORD.value,
+                default=defaults.get(ConfigKey.ENABLE_HOTWORD, DEFAULT_ENABLE_HOTWORD),
             ): BooleanSelector(),
             vol.Optional(
-                CONF_HOTWORD,
+                ConfigKey.HOTWORD.value,
                 default=hotword_default,
             ): TextSelector(TextSelectorConfig(multiple=True)),
             vol.Optional(
-                CONF_HOTWORD_MIN_CONFIDENCE,
+                ConfigKey.HOTWORD_MIN_CONFIDENCE.value,
                 default=defaults.get(
-                    CONF_HOTWORD_MIN_CONFIDENCE,
+                    ConfigKey.HOTWORD_MIN_CONFIDENCE,
                     DEFAULT_HOTWORD_MIN_CONFIDENCE,
                 ),
             ): NumberSelector(

--- a/custom_components/assist_canonicalizer/const.py
+++ b/custom_components/assist_canonicalizer/const.py
@@ -6,59 +6,78 @@ from math import ceil
 DOMAIN = "assist_canonicalizer"
 NAME = "Assist Canonicalizer"
 
-CONF_FALLBACK_AGENT_ID = "fallback_agent_id"
-CONF_MIN_CONFIDENCE = "min_confidence"
-CONF_MIN_MARGIN = "min_margin"
-CONF_ENABLE_HOTWORD = "enable_hotword"
-CONF_HOTWORD = "hotword"
-CONF_HOTWORD_MIN_CONFIDENCE = "hotword_min_confidence"
+
+class ConfigKey(StrEnum):
+    """Configuration keys for Assist Canonicalizer."""
+
+    FALLBACK_AGENT_ID = "fallback_agent_id"
+    MIN_CONFIDENCE = "min_confidence"
+    MIN_MARGIN = "min_margin"
+    ENABLE_HOTWORD = "enable_hotword"
+    HOTWORD = "hotword"
+    HOTWORD_MIN_CONFIDENCE = "hotword_min_confidence"
+
 
 DATA_RUNTIME = "runtime"
 
-SERVICE_CLEAR_INDEX = "clear_index"
-SERVICE_DIAGNOSTICS = "diagnostics"
-SERVICE_DUMP_CANDIDATES = "dump_candidates"
-SERVICE_REBUILD_INDEX = "rebuild_index"
-SERVICE_SET_FALLBACK_AGENT = "set_fallback_agent"
-SERVICE_TEST_MATCH = "test_match"
 
-ATTR_ACCEPTED = "accepted"
-ATTR_AGENT_ID = "agent_id"
-ATTR_CANDIDATE_COUNT = "candidate_count"
-ATTR_INTENT_NAME = "intent_name"
-ATTR_LANGUAGE = "language"
-ATTR_NORMALIZED_TEXT = "normalized_text"
-ATTR_SELECTED_CANDIDATE = "selected_candidate"
-ATTR_SOURCE = "source"
-ATTR_TEXT = "text"
-ATTR_TOP_CANDIDATES = "top_candidates"
+class ServiceName(StrEnum):
+    """Service names registered by Assist Canonicalizer."""
 
-CONVERSATION_INPUT_AGENT_ID_FIELD = "agent_id"
-CONVERSATION_INPUT_CONTEXT_FIELD = "context"
-CONVERSATION_INPUT_CONVERSATION_ID_FIELD = "conversation_id"
-CONVERSATION_INPUT_DEVICE_ID_FIELD = "device_id"
-CONVERSATION_INPUT_EXTRA_SYSTEM_PROMPT_FIELD = "extra_system_prompt"
-CONVERSATION_INPUT_LANGUAGE_FIELD = "language"
-CONVERSATION_INPUT_SATELLITE_ID_FIELD = "satellite_id"
-CONVERSATION_INPUT_TEXT_FIELD = "text"
-CONVERSATION_INPUT_AREA_CONTEXT_FIELD = "area_context"
+    CLEAR_INDEX = "clear_index"
+    DIAGNOSTICS = "diagnostics"
+    DUMP_CANDIDATES = "dump_candidates"
+    REBUILD_INDEX = "rebuild_index"
+    SET_FALLBACK_AGENT = "set_fallback_agent"
+    TEST_MATCH = "test_match"
+
+
+class AttributeName(StrEnum):
+    """Service parameter and response attribute names."""
+
+    ACCEPTED = "accepted"
+    AGENT_ID = "agent_id"
+    CANDIDATE_COUNT = "candidate_count"
+    INTENT_NAME = "intent_name"
+    LANGUAGE = "language"
+    NORMALIZED_TEXT = "normalized_text"
+    REBUILD = "rebuild"
+    SELECTED_CANDIDATE = "selected_candidate"
+    SOURCE = "source"
+    TEXT = "text"
+    TOP_CANDIDATES = "top_candidates"
+
+
+class ConversationInputField(StrEnum):
+    """Field names on conversation input instances and synthetic contexts."""
+
+    AGENT_ID = "agent_id"
+    AREA_CONTEXT = "area_context"
+    CONTEXT = "context"
+    CONVERSATION_ID = "conversation_id"
+    DEVICE_ID = "device_id"
+    EXTRA_SYSTEM_PROMPT = "extra_system_prompt"
+    LANGUAGE = "language"
+    SATELLITE_ID = "satellite_id"
+    TEXT = "text"
+
 
 CONVERSATION_INPUT_OPTIONAL_FIELDS = (
-    CONVERSATION_INPUT_SATELLITE_ID_FIELD,
-    CONVERSATION_INPUT_EXTRA_SYSTEM_PROMPT_FIELD,
+    ConversationInputField.SATELLITE_ID,
+    ConversationInputField.EXTRA_SYSTEM_PROMPT,
 )
 CONVERSATION_INPUT_REQUIRED_CONTEXT_FIELDS = (
-    CONVERSATION_INPUT_CONTEXT_FIELD,
-    CONVERSATION_INPUT_LANGUAGE_FIELD,
+    ConversationInputField.CONTEXT,
+    ConversationInputField.LANGUAGE,
 )
 CONVERSATION_INPUT_OPTIONAL_CONTEXT_FIELDS = (
-    CONVERSATION_INPUT_CONVERSATION_ID_FIELD,
-    CONVERSATION_INPUT_DEVICE_ID_FIELD,
+    ConversationInputField.CONVERSATION_ID,
+    ConversationInputField.DEVICE_ID,
     *CONVERSATION_INPUT_OPTIONAL_FIELDS,
 )
 CONVERSATION_INPUT_AREA_CONTEXT_FIELDS = (
-    CONVERSATION_INPUT_DEVICE_ID_FIELD,
-    CONVERSATION_INPUT_SATELLITE_ID_FIELD,
+    ConversationInputField.DEVICE_ID,
+    ConversationInputField.SATELLITE_ID,
 )
 
 ASSISTANT_CONVERSATION = "conversation"

--- a/custom_components/assist_canonicalizer/conversation.py
+++ b/custom_components/assist_canonicalizer/conversation.py
@@ -33,15 +33,14 @@ if TYPE_CHECKING:
 from homeassistant.helpers import area_registry, device_registry, entity_registry
 
 from .const import (
-    CONF_FALLBACK_AGENT_ID,
-    CONVERSATION_INPUT_DEVICE_ID_FIELD,
     CONVERSATION_INPUT_OPTIONAL_FIELDS,
-    CONVERSATION_INPUT_SATELLITE_ID_FIELD,
     DATA_RUNTIME,
     DEFAULT_MAX_CANDIDATES,
     DEFAULT_MAX_PREFLIGHT_ATTEMPTS,
     DOMAIN,
     NAME,
+    ConfigKey,
+    ConversationInputField,
     FallbackReason,
 )
 from .indexer import CanonicalIndex
@@ -660,7 +659,7 @@ class AssistCanonicalizerConversationEntity(
 
         area_id: str | None = None
         device_id = user_input.device_id
-        satellite_id = getattr(user_input, CONVERSATION_INPUT_SATELLITE_ID_FIELD, None)
+        satellite_id = getattr(user_input, ConversationInputField.SATELLITE_ID, None)
 
         if (
             satellite_id is not None
@@ -669,7 +668,7 @@ class AssistCanonicalizerConversationEntity(
             area_id = getattr(entity_entry, "area_id", None)
             if satellite_device_id := getattr(
                 entity_entry,
-                CONVERSATION_INPUT_DEVICE_ID_FIELD,
+                ConversationInputField.DEVICE_ID,
                 None,
             ):
                 device_id = satellite_device_id
@@ -1251,7 +1250,9 @@ class AssistCanonicalizerConversationEntity(
         """Return a configured fallback agent without allowing self-forwarding."""
         options = getattr(self._entry, "options", {}) or {}
         data = getattr(self._entry, "data", {}) or {}
-        configured = options.get(CONF_FALLBACK_AGENT_ID) or data.get(CONF_FALLBACK_AGENT_ID)
+        configured = options.get(ConfigKey.FALLBACK_AGENT_ID) or data.get(
+            ConfigKey.FALLBACK_AGENT_ID
+        )
         if not isinstance(configured, str) or configured == self._entry.entry_id:
             return default_agent_id
         return configured

--- a/custom_components/assist_canonicalizer/recognition.py
+++ b/custom_components/assist_canonicalizer/recognition.py
@@ -16,10 +16,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util.json import JsonObjectType
 
 from .const import (
-    CONVERSATION_INPUT_AREA_CONTEXT_FIELD,
     CONVERSATION_INPUT_AREA_CONTEXT_FIELDS,
     CONVERSATION_INPUT_OPTIONAL_CONTEXT_FIELDS,
     CONVERSATION_INPUT_REQUIRED_CONTEXT_FIELDS,
+    ConversationInputField,
 )
 from .normalization import normalize_text
 from .utils import elapsed_ms
@@ -223,7 +223,7 @@ def _forwarded_context_fields(user_input: ConversationInput) -> tuple[str, ...]:
         getattr(user_input, field_name, None) is not None
         for field_name in CONVERSATION_INPUT_AREA_CONTEXT_FIELDS
     ):
-        fields.append(CONVERSATION_INPUT_AREA_CONTEXT_FIELD)
+        fields.append(ConversationInputField.AREA_CONTEXT)
     return tuple(fields)
 
 

--- a/custom_components/assist_canonicalizer/runtime.py
+++ b/custom_components/assist_canonicalizer/runtime.py
@@ -1582,7 +1582,7 @@ def _serialize_candidate(candidate: Candidate) -> JsonObjectType:
     return {
         "text": candidate.text,
         "intent_name": candidate.intent_name,
-        "source": str(candidate.source),
+        "source": candidate.source.value,
         "language": candidate.language,
         "metadata": dict(candidate.metadata),
         "slot_values": list(candidate.slot_values),

--- a/custom_components/assist_canonicalizer/services.py
+++ b/custom_components/assist_canonicalizer/services.py
@@ -22,29 +22,15 @@ from homeassistant.util.json import JsonObjectType, JsonValueType
 from .builtin_intents import language_variant_for
 from .candidate import Candidate
 from .const import (
-    ATTR_ACCEPTED,
-    ATTR_AGENT_ID,
-    ATTR_CANDIDATE_COUNT,
-    ATTR_INTENT_NAME,
-    ATTR_LANGUAGE,
-    ATTR_NORMALIZED_TEXT,
-    ATTR_SELECTED_CANDIDATE,
-    ATTR_SOURCE,
-    ATTR_TEXT,
-    ATTR_TOP_CANDIDATES,
-    CONF_FALLBACK_AGENT_ID,
     DATA_RUNTIME,
     DEFAULT_MAX_DYNAMIC_CANDIDATES,
     DEFAULT_MAX_DYNAMIC_SLOT_VALUES,
     DEFAULT_MAX_REGISTRY_VALUES_NOMINATED,
     DEFAULT_MAX_REGISTRY_VALUES_SCORED_PER_QUERY,
     DOMAIN,
-    SERVICE_CLEAR_INDEX,
-    SERVICE_DIAGNOSTICS,
-    SERVICE_DUMP_CANDIDATES,
-    SERVICE_REBUILD_INDEX,
-    SERVICE_SET_FALLBACK_AGENT,
-    SERVICE_TEST_MATCH,
+    AttributeName,
+    ConfigKey,
+    ServiceName,
 )
 from .indexer import CanonicalIndex
 from .normalization import normalize_text
@@ -55,7 +41,6 @@ from .utils import elapsed_ms, normalize_language, resolve_entry_thresholds
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_REBUILD = "rebuild"
 _CANDIDATE_SAMPLE_LIMIT = 50
 
 
@@ -192,23 +177,27 @@ def validate_supported_language(value: object) -> str:
 
 TEST_MATCH_SCHEMA = vol.Schema(
     {
-        vol.Required(ATTR_TEXT): cv.string,
-        vol.Optional(ATTR_LANGUAGE): validate_supported_language,
+        vol.Required(AttributeName.TEXT.value): cv.string,
+        vol.Optional(AttributeName.LANGUAGE.value): validate_supported_language,
     }
 )
 
-REBUILD_INDEX_SCHEMA = vol.Schema({vol.Optional(ATTR_LANGUAGE): validate_supported_language})
-CLEAR_INDEX_SCHEMA = vol.Schema({vol.Optional(ATTR_LANGUAGE): validate_supported_language})
+REBUILD_INDEX_SCHEMA = vol.Schema(
+    {vol.Optional(AttributeName.LANGUAGE.value): validate_supported_language}
+)
+CLEAR_INDEX_SCHEMA = vol.Schema(
+    {vol.Optional(AttributeName.LANGUAGE.value): validate_supported_language}
+)
 DIAGNOSTICS_SCHEMA = vol.Schema({})
 DUMP_CANDIDATES_SCHEMA = vol.Schema(
     {
-        vol.Optional(ATTR_LANGUAGE): validate_supported_language,
-        vol.Optional(ATTR_REBUILD, default=False): cv.boolean,
+        vol.Optional(AttributeName.LANGUAGE.value): validate_supported_language,
+        vol.Optional(AttributeName.REBUILD.value, default=False): cv.boolean,
     }
 )
 SET_FALLBACK_AGENT_SCHEMA = vol.Schema(
     {
-        vol.Required(ATTR_AGENT_ID): vol.All(
+        vol.Required(AttributeName.AGENT_ID.value): vol.All(
             cv.string,
             str.strip,
             vol.Length(min=1),
@@ -263,35 +252,35 @@ def async_setup_services(hass: HomeAssistant) -> None:
     """Register Assist Canonicalizer services."""
     hass.services.async_register(
         DOMAIN,
-        SERVICE_SET_FALLBACK_AGENT,
+        ServiceName.SET_FALLBACK_AGENT,
         _registered_service_handler(hass, _handle_set_fallback_agent),
         schema=SET_FALLBACK_AGENT_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
         DOMAIN,
-        SERVICE_TEST_MATCH,
+        ServiceName.TEST_MATCH,
         _registered_service_handler(hass, _handle_test_match),
         schema=TEST_MATCH_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
     hass.services.async_register(
         DOMAIN,
-        SERVICE_REBUILD_INDEX,
+        ServiceName.REBUILD_INDEX,
         _registered_service_handler(hass, _handle_rebuild_index),
         schema=REBUILD_INDEX_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
     hass.services.async_register(
         DOMAIN,
-        SERVICE_CLEAR_INDEX,
+        ServiceName.CLEAR_INDEX,
         _registered_service_handler(hass, _handle_clear_index),
         schema=CLEAR_INDEX_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
     hass.services.async_register(
         DOMAIN,
-        SERVICE_DIAGNOSTICS,
+        ServiceName.DIAGNOSTICS,
         _registered_service_handler(hass, _handle_diagnostics),
         schema=DIAGNOSTICS_SCHEMA,
         supports_response=SupportsResponse.ONLY,
@@ -299,7 +288,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
     hass.services.async_register(
         DOMAIN,
-        SERVICE_DUMP_CANDIDATES,
+        ServiceName.DUMP_CANDIDATES,
         _registered_service_handler(hass, _handle_dump_candidates),
         schema=DUMP_CANDIDATES_SCHEMA,
         supports_response=SupportsResponse.ONLY,
@@ -308,12 +297,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
 def async_unload_services(hass: HomeAssistant) -> None:
     """Remove Assist Canonicalizer services."""
-    hass.services.async_remove(DOMAIN, SERVICE_SET_FALLBACK_AGENT)
-    hass.services.async_remove(DOMAIN, SERVICE_TEST_MATCH)
-    hass.services.async_remove(DOMAIN, SERVICE_REBUILD_INDEX)
-    hass.services.async_remove(DOMAIN, SERVICE_CLEAR_INDEX)
-    hass.services.async_remove(DOMAIN, SERVICE_DIAGNOSTICS)
-    hass.services.async_remove(DOMAIN, SERVICE_DUMP_CANDIDATES)
+    hass.services.async_remove(DOMAIN, ServiceName.SET_FALLBACK_AGENT)
+    hass.services.async_remove(DOMAIN, ServiceName.TEST_MATCH)
+    hass.services.async_remove(DOMAIN, ServiceName.REBUILD_INDEX)
+    hass.services.async_remove(DOMAIN, ServiceName.CLEAR_INDEX)
+    hass.services.async_remove(DOMAIN, ServiceName.DIAGNOSTICS)
+    hass.services.async_remove(DOMAIN, ServiceName.DUMP_CANDIDATES)
 
 
 def _wrap_service_errors[R](
@@ -359,7 +348,7 @@ async def _handle_set_fallback_agent(hass: HomeAssistant, call: ServiceCall) -> 
     if entry is None:
         raise HomeAssistantError("Assist Canonicalizer config entry is not available")
 
-    agent_id = call.data[ATTR_AGENT_ID]
+    agent_id = call.data[AttributeName.AGENT_ID]
     if agent_id == entry.entry_id:
         raise HomeAssistantError("Assist Canonicalizer cannot use itself as the fallback agent")
 
@@ -374,10 +363,10 @@ async def _handle_set_fallback_agent(hass: HomeAssistant, call: ServiceCall) -> 
 
     previous_agent_id = _configured_fallback_agent_id(entry)
     options = dict(getattr(entry, "options", {}) or {})
-    options[CONF_FALLBACK_AGENT_ID] = agent_id
+    options[ConfigKey.FALLBACK_AGENT_ID] = agent_id
     config_entry_changed = hass.config_entries.async_update_entry(entry, options=options)
     return {
-        CONF_FALLBACK_AGENT_ID: agent_id,
+        ConfigKey.FALLBACK_AGENT_ID: agent_id,
         "previous_fallback_agent_id": previous_agent_id,
         "changed": config_entry_changed,
     }
@@ -388,7 +377,7 @@ async def _handle_test_match(hass: HomeAssistant, call: ServiceCall) -> TestMatc
     """Return ranked candidates for a text input with lexical scoring and custom thresholds."""
     runtime, entry = _runtime_entry_from_hass(hass)
     language = _service_language(hass, call)
-    text = call.data[ATTR_TEXT]
+    text = call.data[AttributeName.TEXT]
     index = await _index_for_language(hass, runtime, language, rebuild_if_missing=True)
     if index is None:
         raise HomeAssistantError("Assist Canonicalizer index could not be built")
@@ -414,24 +403,22 @@ async def _handle_test_match(hass: HomeAssistant, call: ServiceCall) -> TestMatc
     )
     selected = decision.accepted_candidate
 
-    return {
-        ATTR_LANGUAGE: language,
-        ATTR_NORMALIZED_TEXT: normalize_text(text),
-        ATTR_CANDIDATE_COUNT: index.candidate_count,
-        "dynamic_candidate_count": runtime.diagnostics.dynamic_candidate_count,
-        "evaluation": {
+    return TestMatchPayload(
+        language=language,
+        normalized_text=normalize_text(text),
+        candidate_count=index.candidate_count,
+        dynamic_candidate_count=runtime.diagnostics.dynamic_candidate_count,
+        evaluation={
             "scope": "lexical",
             "candidate_metadata_authoritative": False,
             "live_recognition": "not_run",
             "production_decision_path": "/api/conversation/process",
         },
-        "confidence_gate": decision.as_dict(),
-        ATTR_ACCEPTED: selected is not None,
-        ATTR_SELECTED_CANDIDATE: (
-            _ranked_candidate_response(selected, query=text) if selected else None
-        ),
-        ATTR_TOP_CANDIDATES: [_ranked_candidate_response(item, query=text) for item in ranked],
-    }
+        confidence_gate=decision.as_dict(),
+        accepted=selected is not None,
+        selected_candidate=(_ranked_candidate_response(selected, query=text) if selected else None),
+        top_candidates=[_ranked_candidate_response(item, query=text) for item in ranked],
+    )
 
 
 @_wrap_service_errors("Index rebuild")
@@ -443,30 +430,30 @@ async def _handle_rebuild_index(hass: HomeAssistant, call: ServiceCall) -> Rebui
     index = await _rebuild_index(hass, runtime, language)
     if index is None:
         raise HomeAssistantError("Index rebuild failed or was cancelled")
-    return {
-        ATTR_LANGUAGE: language,
-        ATTR_CANDIDATE_COUNT: index.candidate_count,
-        "rebuild_latency_ms": elapsed_ms(started_at),
-    }
+    return RebuildPayload(
+        language=language,
+        candidate_count=index.candidate_count,
+        rebuild_latency_ms=elapsed_ms(started_at),
+    )
 
 
 @_wrap_service_errors("Clear index")
 async def _handle_clear_index(hass: HomeAssistant, call: ServiceCall) -> ClearIndexPayload:
     """Clear one language index or all indexes."""
     runtime = _runtime_from_hass(hass)
-    requested_language = call.data.get(ATTR_LANGUAGE)
+    requested_language = call.data.get(AttributeName.LANGUAGE)
     language = (
         normalize_language(requested_language) if isinstance(requested_language, str) else None
     )
     clear_result = await runtime.async_clear_index(hass, language)
-    return {
-        ATTR_LANGUAGE: language,
-        "scope": "all" if language is None else "language",
-        "cleared_cached_languages": list(clear_result.cleared_cached_languages),
-        "cleared_candidate_count": clear_result.cleared_candidate_count,
-        "remaining_candidate_count": clear_result.remaining_candidate_count,
-        "remaining_cached_languages": list(clear_result.remaining_cached_languages),
-    }
+    return ClearIndexPayload(
+        language=language,
+        scope="all" if language is None else "language",
+        cleared_cached_languages=list(clear_result.cleared_cached_languages),
+        cleared_candidate_count=clear_result.cleared_candidate_count,
+        remaining_candidate_count=clear_result.remaining_candidate_count,
+        remaining_cached_languages=list(clear_result.remaining_cached_languages),
+    )
 
 
 @_wrap_service_errors("Diagnostics")
@@ -474,12 +461,12 @@ async def _handle_diagnostics(hass: HomeAssistant, call: ServiceCall) -> JsonObj
     """Return runtime diagnostics."""
     runtime = _runtime_from_hass(hass)
     diagnostics = runtime.diagnostics.as_dict()
-    diagnostics.pop(ATTR_CANDIDATE_COUNT, None)
+    diagnostics.pop(AttributeName.CANDIDATE_COUNT, None)
     diagnostics.pop("index_version", None)
     cached_indexes: JsonObjectType = {}
     for language, index in sorted(runtime.indexes.items()):
         index_summary: JsonObjectType = {
-            ATTR_CANDIDATE_COUNT: index.candidate_count,
+            AttributeName.CANDIDATE_COUNT: index.candidate_count,
             "version": index.version,
         }
         cached_indexes[language] = index_summary
@@ -511,7 +498,7 @@ async def _handle_dump_candidates(hass: HomeAssistant, call: ServiceCall) -> Dum
     """Return candidate pool details for a language."""
     runtime = _runtime_from_hass(hass)
     language = _service_language(hass, call)
-    should_rebuild = bool(call.data.get(ATTR_REBUILD, False))
+    should_rebuild = bool(call.data.get(AttributeName.REBUILD, False))
     rebuild_latency_ms: float | None = None
     if should_rebuild:
         started_at = time.monotonic()
@@ -526,21 +513,21 @@ async def _handle_dump_candidates(hass: HomeAssistant, call: ServiceCall) -> Dum
 
     intent_source_counts = await hass.async_add_executor_job(runtime.source_counts, language)
     if index is None:
-        empty_sample: CandidateSamplePayload = {
-            "truncated": False,
-            "candidates": [],
-        }
-        return {
-            ATTR_LANGUAGE: language,
-            ATTR_CANDIDATE_COUNT: 0,
-            "index_status": index_status,
-            "rebuild_latency_ms": rebuild_latency_ms,
-            "intent_source_counts": intent_source_counts,
-            "candidate_source_counts": {},
-            "intent_counts": {},
-            "registry_slot_counts": _registry_slot_counts(runtime),
-            "candidate_sample": empty_sample,
-        }
+        empty_sample = CandidateSamplePayload(
+            truncated=False,
+            candidates=[],
+        )
+        return DumpCandidatesPayload(
+            language=language,
+            candidate_count=0,
+            index_status=index_status,
+            rebuild_latency_ms=rebuild_latency_ms,
+            intent_source_counts=intent_source_counts,
+            candidate_source_counts={},
+            intent_counts={},
+            registry_slot_counts=_registry_slot_counts(runtime),
+            candidate_sample=empty_sample,
+        )
 
     source_counts, intent_counts = await hass.async_add_executor_job(
         _count_candidate_sources_and_intents, index
@@ -549,21 +536,21 @@ async def _handle_dump_candidates(hass: HomeAssistant, call: ServiceCall) -> Dum
         _ranked_candidate_candidate_response(candidate)
         for candidate in index.candidates[:_CANDIDATE_SAMPLE_LIMIT]
     ]
-    candidate_sample: CandidateSamplePayload = {
-        "truncated": index.candidate_count > len(sample_candidates),
-        "candidates": sample_candidates,
-    }
-    return {
-        ATTR_LANGUAGE: language,
-        ATTR_CANDIDATE_COUNT: index.candidate_count,
-        "index_status": index_status,
-        "rebuild_latency_ms": rebuild_latency_ms,
-        "intent_source_counts": intent_source_counts,
-        "candidate_source_counts": source_counts,
-        "intent_counts": dict(sorted(intent_counts.items())),
-        "registry_slot_counts": _registry_slot_counts(runtime),
-        "candidate_sample": candidate_sample,
-    }
+    candidate_sample = CandidateSamplePayload(
+        truncated=index.candidate_count > len(sample_candidates),
+        candidates=sample_candidates,
+    )
+    return DumpCandidatesPayload(
+        language=language,
+        candidate_count=index.candidate_count,
+        index_status=index_status,
+        rebuild_latency_ms=rebuild_latency_ms,
+        intent_source_counts=intent_source_counts,
+        candidate_source_counts=source_counts,
+        intent_counts=dict(sorted(intent_counts.items())),
+        registry_slot_counts=_registry_slot_counts(runtime),
+        candidate_sample=candidate_sample,
+    )
 
 
 async def _index_for_language(
@@ -632,7 +619,7 @@ def _configured_fallback_agent_id(entry: ConfigEntry) -> str:
     """Return the effective fallback agent configured before a service update."""
     options = getattr(entry, "options", {}) or {}
     data = getattr(entry, "data", {}) or {}
-    configured = options.get(CONF_FALLBACK_AGENT_ID) or data.get(CONF_FALLBACK_AGENT_ID)
+    configured = options.get(ConfigKey.FALLBACK_AGENT_ID) or data.get(ConfigKey.FALLBACK_AGENT_ID)
     if not isinstance(configured, str) or configured == entry.entry_id:
         return HOME_ASSISTANT_AGENT
     return configured
@@ -640,7 +627,7 @@ def _configured_fallback_agent_id(entry: ConfigEntry) -> str:
 
 def _service_language(hass: HomeAssistant, call: ServiceCall) -> str:
     """Return the service language, falling back to Home Assistant config."""
-    language = call.data.get(ATTR_LANGUAGE) or hass.config.language
+    language = call.data.get(AttributeName.LANGUAGE) or hass.config.language
     return normalize_language(str(language))
 
 
@@ -654,15 +641,15 @@ def _registry_slot_counts(runtime: CanonicalizerRuntime) -> dict[str, int]:
 def _ranked_candidate_candidate_response(candidate: Candidate) -> CandidateMetadataPayload:
     """Return serializable candidate metadata without scores."""
     wildcard_slots = sorted({wildcard_name for _index, wildcard_name in candidate.wildcard_infos})
-    return {
-        ATTR_TEXT: candidate.text,
-        ATTR_INTENT_NAME: candidate.intent_name,
-        ATTR_SOURCE: candidate.source.value,
-        ATTR_NORMALIZED_TEXT: candidate.normalized_text,
-        "slots": candidate.parsed_slots,
-        "wildcard_slots": wildcard_slots,
-        "sentence_template": candidate.metadata.get("sentence_template"),
-    }
+    return CandidateMetadataPayload(
+        text=candidate.text,
+        intent_name=candidate.intent_name,
+        source=candidate.source.value,
+        normalized_text=candidate.normalized_text,
+        slots=candidate.parsed_slots,
+        wildcard_slots=wildcard_slots,
+        sentence_template=candidate.metadata.get("sentence_template"),
+    )
 
 
 def _ranked_candidate_response(
@@ -684,12 +671,12 @@ def _ranked_candidate_response(
         "penalty": ranked.scores.penalty,
         "final": ranked.scores.final_score,
     }
-    return {
-        ATTR_TEXT: text,
-        ATTR_INTENT_NAME: candidate.intent_name,
-        ATTR_SOURCE: candidate.source.value,
-        ATTR_NORMALIZED_TEXT: normalized_text,
-        "slots": candidate.parsed_slots,
-        "wildcard_replacements": replacements,
-        "scores": scores,
-    }
+    return RankedCandidatePayload(
+        text=text,
+        intent_name=candidate.intent_name,
+        source=candidate.source.value,
+        normalized_text=normalized_text,
+        slots=candidate.parsed_slots,
+        wildcard_replacements=replacements,
+        scores=scores,
+    )

--- a/custom_components/assist_canonicalizer/utils.py
+++ b/custom_components/assist_canonicalizer/utils.py
@@ -17,17 +17,13 @@ from homeassistant.config_entries import ConfigEntry
 
 from .builtin_intents import language_variant_for
 from .const import (
-    CONF_ENABLE_HOTWORD,
-    CONF_HOTWORD,
-    CONF_HOTWORD_MIN_CONFIDENCE,
-    CONF_MIN_CONFIDENCE,
-    CONF_MIN_MARGIN,
     DEFAULT_ENABLE_HOTWORD,
     DEFAULT_HOTWORD,
     DEFAULT_HOTWORD_MIN_CONFIDENCE,
     DEFAULT_MIN_CONFIDENCE,
     DEFAULT_MIN_MARGIN,
     PRESERVED_UNIT_SUFFIXES,
+    ConfigKey,
 )
 from .normalization import normalize_text
 
@@ -69,12 +65,12 @@ def resolve_entry_thresholds(entry: ConfigEntry | None) -> tuple[float, float]:
     options = (getattr(entry, "options", {}) or {}) if entry is not None else {}
     data = (getattr(entry, "data", {}) or {}) if entry is not None else {}
     min_confidence = options.get(
-        CONF_MIN_CONFIDENCE,
-        data.get(CONF_MIN_CONFIDENCE, DEFAULT_MIN_CONFIDENCE),
+        ConfigKey.MIN_CONFIDENCE,
+        data.get(ConfigKey.MIN_CONFIDENCE, DEFAULT_MIN_CONFIDENCE),
     )
     min_margin = options.get(
-        CONF_MIN_MARGIN,
-        data.get(CONF_MIN_MARGIN, DEFAULT_MIN_MARGIN),
+        ConfigKey.MIN_MARGIN,
+        data.get(ConfigKey.MIN_MARGIN, DEFAULT_MIN_MARGIN),
     )
     return min_confidence, min_margin
 
@@ -126,18 +122,18 @@ def resolve_entry_hotword_options(
     data = (getattr(entry, "data", {}) or {}) if entry is not None else {}
     enable_hotword = bool(
         options.get(
-            CONF_ENABLE_HOTWORD,
-            data.get(CONF_ENABLE_HOTWORD, DEFAULT_ENABLE_HOTWORD),
+            ConfigKey.ENABLE_HOTWORD,
+            data.get(ConfigKey.ENABLE_HOTWORD, DEFAULT_ENABLE_HOTWORD),
         )
     )
     raw_hotword = options.get(
-        CONF_HOTWORD,
-        data.get(CONF_HOTWORD, DEFAULT_HOTWORD),
+        ConfigKey.HOTWORD,
+        data.get(ConfigKey.HOTWORD, DEFAULT_HOTWORD),
     )
     hotwords = tuple(normalize_hotword_list(raw_hotword))
     raw_min_confidence = options.get(
-        CONF_HOTWORD_MIN_CONFIDENCE,
-        data.get(CONF_HOTWORD_MIN_CONFIDENCE, DEFAULT_HOTWORD_MIN_CONFIDENCE),
+        ConfigKey.HOTWORD_MIN_CONFIDENCE,
+        data.get(ConfigKey.HOTWORD_MIN_CONFIDENCE, DEFAULT_HOTWORD_MIN_CONFIDENCE),
     )
     min_confidence: float
     if isinstance(raw_min_confidence, (int, float)):

--- a/tests/integration/test_compatibility.py
+++ b/tests/integration/test_compatibility.py
@@ -18,22 +18,13 @@ from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry, async_fire_time_changed
 
 from custom_components.assist_canonicalizer.const import (
-    ATTR_AGENT_ID,
-    ATTR_CANDIDATE_COUNT,
-    ATTR_LANGUAGE,
-    ATTR_TEXT,
-    CONF_MIN_CONFIDENCE,
-    CONF_MIN_MARGIN,
     DATA_RUNTIME,
     DEFAULT_MIN_CONFIDENCE,
     DEFAULT_MIN_MARGIN,
     DOMAIN,
-    SERVICE_CLEAR_INDEX,
-    SERVICE_DIAGNOSTICS,
-    SERVICE_DUMP_CANDIDATES,
-    SERVICE_REBUILD_INDEX,
-    SERVICE_SET_FALLBACK_AGENT,
-    SERVICE_TEST_MATCH,
+    AttributeName,
+    ConfigKey,
+    ServiceName,
 )
 from custom_components.assist_canonicalizer.recognition import (
     RecognitionKind,
@@ -57,8 +48,8 @@ async def test_home_assistant_functional_contract(
         title="Assist Canonicalizer",
         data={},
         options={
-            CONF_MIN_CONFIDENCE: 1.0,
-            CONF_MIN_MARGIN: 1.0,
+            ConfigKey.MIN_CONFIDENCE: 1.0,
+            ConfigKey.MIN_MARGIN: 1.0,
         },
     )
     entry.add_to_hass(hass)
@@ -67,57 +58,57 @@ async def test_home_assistant_functional_contract(
     await hass.async_block_till_done()
 
     assert conversation.async_get_agent_info(hass, entry.entry_id) is not None
-    assert hass.services.has_service(DOMAIN, SERVICE_REBUILD_INDEX)
-    assert hass.services.has_service(DOMAIN, SERVICE_TEST_MATCH)
-    assert hass.services.has_service(DOMAIN, SERVICE_CLEAR_INDEX)
-    assert hass.services.has_service(DOMAIN, SERVICE_DUMP_CANDIDATES)
-    assert hass.services.has_service(DOMAIN, SERVICE_DIAGNOSTICS)
-    assert hass.services.has_service(DOMAIN, SERVICE_SET_FALLBACK_AGENT)
+    assert hass.services.has_service(DOMAIN, ServiceName.REBUILD_INDEX)
+    assert hass.services.has_service(DOMAIN, ServiceName.TEST_MATCH)
+    assert hass.services.has_service(DOMAIN, ServiceName.CLEAR_INDEX)
+    assert hass.services.has_service(DOMAIN, ServiceName.DUMP_CANDIDATES)
+    assert hass.services.has_service(DOMAIN, ServiceName.DIAGNOSTICS)
+    assert hass.services.has_service(DOMAIN, ServiceName.SET_FALLBACK_AGENT)
 
     # 1. Rebuild index service
     rebuild_response = await hass.services.async_call(
         DOMAIN,
-        SERVICE_REBUILD_INDEX,
-        {ATTR_LANGUAGE: "en"},
+        ServiceName.REBUILD_INDEX,
+        {AttributeName.LANGUAGE: "en"},
         blocking=True,
         return_response=True,
     )
     assert isinstance(rebuild_response, dict)
-    assert rebuild_response[ATTR_LANGUAGE] == "en"
-    candidate_count = rebuild_response[ATTR_CANDIDATE_COUNT]
+    assert rebuild_response[AttributeName.LANGUAGE] == "en"
+    candidate_count = rebuild_response[AttributeName.CANDIDATE_COUNT]
     assert isinstance(candidate_count, int)
     assert candidate_count > 0
 
     # 2. Test match service
     test_match_response = await hass.services.async_call(
         DOMAIN,
-        SERVICE_TEST_MATCH,
-        {ATTR_TEXT: "turn on kitchen light", ATTR_LANGUAGE: "en"},
+        ServiceName.TEST_MATCH,
+        {AttributeName.TEXT: "turn on kitchen light", AttributeName.LANGUAGE: "en"},
         blocking=True,
         return_response=True,
     )
     assert isinstance(test_match_response, dict)
-    assert test_match_response[ATTR_LANGUAGE] == "en"
+    assert test_match_response[AttributeName.LANGUAGE] == "en"
     assert "confidence_gate" in test_match_response
     assert "top_candidates" in test_match_response
 
     # 3. Dump candidates service
     dump_response = await hass.services.async_call(
         DOMAIN,
-        SERVICE_DUMP_CANDIDATES,
-        {ATTR_LANGUAGE: "en"},
+        ServiceName.DUMP_CANDIDATES,
+        {AttributeName.LANGUAGE: "en"},
         blocking=True,
         return_response=True,
     )
     assert isinstance(dump_response, dict)
-    assert dump_response[ATTR_LANGUAGE] == "en"
+    assert dump_response[AttributeName.LANGUAGE] == "en"
     assert "candidate_sample" in dump_response
 
     # 4. Set fallback agent service
     fallback_response = await hass.services.async_call(
         DOMAIN,
-        SERVICE_SET_FALLBACK_AGENT,
-        {ATTR_AGENT_ID: HOME_ASSISTANT_AGENT},
+        ServiceName.SET_FALLBACK_AGENT,
+        {AttributeName.AGENT_ID: HOME_ASSISTANT_AGENT},
         blocking=True,
         return_response=True,
     )
@@ -169,7 +160,7 @@ async def test_home_assistant_functional_contract(
     # 6. Diagnostics service
     diagnostics = await hass.services.async_call(
         DOMAIN,
-        SERVICE_DIAGNOSTICS,
+        ServiceName.DIAGNOSTICS,
         {},
         blocking=True,
         return_response=True,
@@ -182,24 +173,24 @@ async def test_home_assistant_functional_contract(
     # 7. Clear index service
     clear_response = await hass.services.async_call(
         DOMAIN,
-        SERVICE_CLEAR_INDEX,
-        {ATTR_LANGUAGE: "en"},
+        ServiceName.CLEAR_INDEX,
+        {AttributeName.LANGUAGE: "en"},
         blocking=True,
         return_response=True,
     )
     assert isinstance(clear_response, dict)
-    assert clear_response[ATTR_LANGUAGE] == "en"
+    assert clear_response[AttributeName.LANGUAGE] == "en"
     assert "cleared_cached_languages" in clear_response
 
     # 8. Unload entry
     assert await hass.config_entries.async_unload(entry.entry_id)
     assert conversation.async_get_agent_info(hass, entry.entry_id) is None
-    assert not hass.services.has_service(DOMAIN, SERVICE_REBUILD_INDEX)
-    assert not hass.services.has_service(DOMAIN, SERVICE_TEST_MATCH)
-    assert not hass.services.has_service(DOMAIN, SERVICE_CLEAR_INDEX)
-    assert not hass.services.has_service(DOMAIN, SERVICE_DUMP_CANDIDATES)
-    assert not hass.services.has_service(DOMAIN, SERVICE_DIAGNOSTICS)
-    assert not hass.services.has_service(DOMAIN, SERVICE_SET_FALLBACK_AGENT)
+    assert not hass.services.has_service(DOMAIN, ServiceName.REBUILD_INDEX)
+    assert not hass.services.has_service(DOMAIN, ServiceName.TEST_MATCH)
+    assert not hass.services.has_service(DOMAIN, ServiceName.CLEAR_INDEX)
+    assert not hass.services.has_service(DOMAIN, ServiceName.DUMP_CANDIDATES)
+    assert not hass.services.has_service(DOMAIN, ServiceName.DIAGNOSTICS)
+    assert not hass.services.has_service(DOMAIN, ServiceName.SET_FALLBACK_AGENT)
 
 
 @pytest.mark.asyncio
@@ -354,8 +345,8 @@ async def test_config_and_options_flow_framework_contract(hass: HomeAssistant) -
         form["flow_id"],
         {
             "fallback_agent_id": HOME_ASSISTANT_AGENT,
-            CONF_MIN_CONFIDENCE: DEFAULT_MIN_CONFIDENCE,
-            CONF_MIN_MARGIN: DEFAULT_MIN_MARGIN,
+            ConfigKey.MIN_CONFIDENCE: DEFAULT_MIN_CONFIDENCE,
+            ConfigKey.MIN_MARGIN: DEFAULT_MIN_MARGIN,
         },
     )
     assert created.get("type") is FlowResultType.CREATE_ENTRY
@@ -372,13 +363,13 @@ async def test_config_and_options_flow_framework_contract(hass: HomeAssistant) -
         options_form["flow_id"],
         {
             "fallback_agent_id": HOME_ASSISTANT_AGENT,
-            CONF_MIN_CONFIDENCE: 0.7,
-            CONF_MIN_MARGIN: 0.08,
+            ConfigKey.MIN_CONFIDENCE: 0.7,
+            ConfigKey.MIN_MARGIN: 0.08,
         },
     )
     assert options_created.get("type") is FlowResultType.CREATE_ENTRY
-    assert entry.options[CONF_MIN_CONFIDENCE] == 0.7
-    assert entry.options[CONF_MIN_MARGIN] == 0.08
+    assert entry.options[ConfigKey.MIN_CONFIDENCE] == 0.7
+    assert entry.options[ConfigKey.MIN_MARGIN] == 0.08
 
     duplicate = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -19,23 +19,11 @@ import custom_components.assist_canonicalizer.conversation as conversation_platf
 from custom_components.assist_canonicalizer import _discover_pipeline_languages
 from custom_components.assist_canonicalizer.candidate import Candidate
 from custom_components.assist_canonicalizer.const import (
-    CONF_ENABLE_HOTWORD,
-    CONF_FALLBACK_AGENT_ID,
-    CONF_HOTWORD,
-    CONF_HOTWORD_MIN_CONFIDENCE,
-    CONF_MIN_CONFIDENCE,
-    CONF_MIN_MARGIN,
-    CONVERSATION_INPUT_AGENT_ID_FIELD,
-    CONVERSATION_INPUT_CONTEXT_FIELD,
-    CONVERSATION_INPUT_CONVERSATION_ID_FIELD,
-    CONVERSATION_INPUT_DEVICE_ID_FIELD,
-    CONVERSATION_INPUT_EXTRA_SYSTEM_PROMPT_FIELD,
-    CONVERSATION_INPUT_LANGUAGE_FIELD,
     CONVERSATION_INPUT_OPTIONAL_FIELDS,
-    CONVERSATION_INPUT_SATELLITE_ID_FIELD,
-    CONVERSATION_INPUT_TEXT_FIELD,
     DATA_RUNTIME,
     DOMAIN,
+    ConfigKey,
+    ConversationInputField,
     FallbackReason,
 )
 from custom_components.assist_canonicalizer.conversation import (
@@ -63,20 +51,20 @@ class MockConversationInput(ConversationInput):
         """Initialize."""
         sig = inspect.signature(super().__init__)
         kwargs: dict[str, Any] = {
-            CONVERSATION_INPUT_TEXT_FIELD: text,
-            CONVERSATION_INPUT_CONTEXT_FIELD: Context(),
-            CONVERSATION_INPUT_CONVERSATION_ID_FIELD: conversation_id,
-            CONVERSATION_INPUT_DEVICE_ID_FIELD: None,
-            CONVERSATION_INPUT_LANGUAGE_FIELD: language,
+            ConversationInputField.TEXT: text,
+            ConversationInputField.CONTEXT: Context(),
+            ConversationInputField.CONVERSATION_ID: conversation_id,
+            ConversationInputField.DEVICE_ID: None,
+            ConversationInputField.LANGUAGE: language,
         }
-        if CONVERSATION_INPUT_AGENT_ID_FIELD in sig.parameters:
-            kwargs[CONVERSATION_INPUT_AGENT_ID_FIELD] = "test_agent"
-        if CONVERSATION_INPUT_SATELLITE_ID_FIELD in sig.parameters:
-            kwargs[CONVERSATION_INPUT_SATELLITE_ID_FIELD] = None
+        if ConversationInputField.AGENT_ID in sig.parameters:
+            kwargs[ConversationInputField.AGENT_ID] = "test_agent"
+        if ConversationInputField.SATELLITE_ID in sig.parameters:
+            kwargs[ConversationInputField.SATELLITE_ID] = None
         super().__init__(**kwargs)
-        if not hasattr(self, CONVERSATION_INPUT_AGENT_ID_FIELD):
+        if not hasattr(self, ConversationInputField.AGENT_ID):
             self.agent_id = "test_agent"
-        if not hasattr(self, CONVERSATION_INPUT_SATELLITE_ID_FIELD):
+        if not hasattr(self, ConversationInputField.SATELLITE_ID):
             self.satellite_id = None
 
 
@@ -124,12 +112,12 @@ async def test_delegate_text_filters_newer_home_assistant_arguments(
         frozenset(
             {
                 "hass",
-                CONVERSATION_INPUT_TEXT_FIELD,
-                CONVERSATION_INPUT_CONVERSATION_ID_FIELD,
-                CONVERSATION_INPUT_CONTEXT_FIELD,
-                CONVERSATION_INPUT_LANGUAGE_FIELD,
-                CONVERSATION_INPUT_AGENT_ID_FIELD,
-                CONVERSATION_INPUT_DEVICE_ID_FIELD,
+                ConversationInputField.TEXT,
+                ConversationInputField.CONVERSATION_ID,
+                ConversationInputField.CONTEXT,
+                ConversationInputField.LANGUAGE,
+                ConversationInputField.AGENT_ID,
+                ConversationInputField.DEVICE_ID,
             }
         ),
     )
@@ -178,8 +166,8 @@ async def test_delegate_text_forwards_newer_home_assistant_arguments(
         agent_id=HOME_ASSISTANT_AGENT,
         device_id=user_input.device_id,
         **{
-            CONVERSATION_INPUT_SATELLITE_ID_FIELD: user_input.satellite_id,
-            CONVERSATION_INPUT_EXTRA_SYSTEM_PROMPT_FIELD: user_input.extra_system_prompt,
+            ConversationInputField.SATELLITE_ID: user_input.satellite_id,
+            ConversationInputField.EXTRA_SYSTEM_PROMPT: user_input.extra_system_prompt,
         },
     )
 
@@ -1296,7 +1284,7 @@ async def test_recovery_handler_error_routes_to_fallback_agent() -> None:
     entry.options = {
         "min_confidence": 0.60,
         "min_margin": 0.05,
-        CONF_FALLBACK_AGENT_ID: "llm_agent",
+        ConfigKey.FALLBACK_AGENT_ID: "llm_agent",
     }
     runtime = CanonicalizerRuntime()
     runtime.indexes["en"] = MagicMock(candidate_count=2)
@@ -1337,9 +1325,7 @@ async def test_recovery_handler_error_routes_to_fallback_agent() -> None:
         "turn on kitchen lamp",
         user_input.text,
     ]
-    assert [
-        call.kwargs[CONVERSATION_INPUT_AGENT_ID_FIELD] for call in converse.await_args_list
-    ] == [
+    assert [call.kwargs[ConversationInputField.AGENT_ID] for call in converse.await_args_list] == [
         HOME_ASSISTANT_AGENT,
         HOME_ASSISTANT_AGENT,
         "llm_agent",
@@ -1748,9 +1734,9 @@ async def test_conversation_resolves_updated_options_without_reload() -> None:
     entry.entry_id = "this_agent"
     entry.data = {}
     entry.options = {
-        CONF_FALLBACK_AGENT_ID: "first_agent",
-        CONF_MIN_CONFIDENCE: 0.60,
-        CONF_MIN_MARGIN: 0.05,
+        ConfigKey.FALLBACK_AGENT_ID: "first_agent",
+        ConfigKey.MIN_CONFIDENCE: 0.60,
+        ConfigKey.MIN_MARGIN: 0.05,
     }
     entity = AssistCanonicalizerConversationEntity(entry, CanonicalizerRuntime())
     user_input = MockConversationInput("turn on the light", "en")
@@ -1765,9 +1751,9 @@ async def test_conversation_resolves_updated_options_without_reload() -> None:
         assert entity._fallback_agent_id("default") == "first_agent"
 
         entry.options = {
-            CONF_FALLBACK_AGENT_ID: "second_agent",
-            CONF_MIN_CONFIDENCE: 0.80,
-            CONF_MIN_MARGIN: 0.10,
+            ConfigKey.FALLBACK_AGENT_ID: "second_agent",
+            ConfigKey.MIN_CONFIDENCE: 0.80,
+            ConfigKey.MIN_MARGIN: 0.10,
         }
         second_request = await entity._async_rank_request(user_input, "en", MagicMock())
 
@@ -1787,7 +1773,9 @@ async def test_conversation_delegate_and_fallback_agent_logic() -> None:
     """Test delegation and fallback agent ID selection branch options."""
     entry = MagicMock()
     entry.entry_id = "this_agent"
-    entry.options = cast(dict[str, Any], {CONF_MIN_CONFIDENCE: 0.60, CONF_MIN_MARGIN: 0.05})
+    entry.options = cast(
+        dict[str, Any], {ConfigKey.MIN_CONFIDENCE: 0.60, ConfigKey.MIN_MARGIN: 0.05}
+    )
     entry.data = {}
     runtime = CanonicalizerRuntime()
     entity = AssistCanonicalizerConversationEntity(entry, runtime)
@@ -1799,24 +1787,24 @@ async def test_conversation_delegate_and_fallback_agent_logic() -> None:
     user_input = MockConversationInput("tắt đèn bếp", "vi")
 
     # 1. Test fallback_agent_id with options
-    entry.options[CONF_FALLBACK_AGENT_ID] = "options_agent"
+    entry.options[ConfigKey.FALLBACK_AGENT_ID] = "options_agent"
     assert entity._fallback_agent_id("default") == "options_agent"
 
     # 2. Test fallback_agent_id with options matching entry_id (self-forwarding prevention)
-    entry.options[CONF_FALLBACK_AGENT_ID] = "this_agent"
+    entry.options[ConfigKey.FALLBACK_AGENT_ID] = "this_agent"
     assert entity._fallback_agent_id("default") == "default"
 
     # 3. Test fallback_agent_id with invalid type
-    entry.options[CONF_FALLBACK_AGENT_ID] = 123
+    entry.options[ConfigKey.FALLBACK_AGENT_ID] = 123
     assert entity._fallback_agent_id("default") == "default"
 
     # 4. Test fallback_agent_id fallback to data
     entry.options = {}
-    entry.data[CONF_FALLBACK_AGENT_ID] = "data_agent"
+    entry.data[ConfigKey.FALLBACK_AGENT_ID] = "data_agent"
     assert entity._fallback_agent_id("default") == "data_agent"
 
     # 5. Test actual delegate_raw_text calls conversation.async_converse
-    entry.options = {CONF_FALLBACK_AGENT_ID: "options_agent"}
+    entry.options = {ConfigKey.FALLBACK_AGENT_ID: "options_agent"}
     mock_result = MagicMock()
     with patch(
         "homeassistant.components.conversation.async_converse", AsyncMock(return_value=mock_result)
@@ -2444,8 +2432,8 @@ async def test_hotword_matched_bypasses_ranking_and_delegates_raw_text() -> None
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: "Jarvis",
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: "Jarvis",
     }
     entry.data = {}
     runtime = CanonicalizerRuntime()
@@ -2473,8 +2461,8 @@ async def test_hotword_disabled_proceeds_to_standard_ranking() -> None:
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {
-        CONF_ENABLE_HOTWORD: False,
-        CONF_HOTWORD: "Jarvis",
+        ConfigKey.ENABLE_HOTWORD: False,
+        ConfigKey.HOTWORD: "Jarvis",
     }
     entry.data = {}
     runtime = CanonicalizerRuntime()
@@ -2500,8 +2488,8 @@ async def test_hotword_enabled_non_matching_query_proceeds_to_ranking() -> None:
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: "Jarvis",
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: "Jarvis",
     }
     entry.data = {}
     runtime = CanonicalizerRuntime()
@@ -2528,9 +2516,9 @@ async def test_hotword_multiword_and_custom_confidence_matched() -> None:
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: "Hey Jarvis",
-        CONF_HOTWORD_MIN_CONFIDENCE: 0.80,
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: "Hey Jarvis",
+        ConfigKey.HOTWORD_MIN_CONFIDENCE: 0.80,
     }
     entry.data = {}
     runtime = CanonicalizerRuntime()
@@ -2557,9 +2545,9 @@ async def test_hotword_below_custom_confidence_proceeds_to_ranking() -> None:
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: "Hey Jarvis",
-        CONF_HOTWORD_MIN_CONFIDENCE: 0.98,
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: "Hey Jarvis",
+        ConfigKey.HOTWORD_MIN_CONFIDENCE: 0.98,
     }
     entry.data = {}
     runtime = CanonicalizerRuntime()
@@ -2587,8 +2575,8 @@ async def test_hotword_list_of_strings_matched() -> None:
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: ["Jarvis", "Computer", "Alexa"],
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: ["Jarvis", "Computer", "Alexa"],
     }
     entry.data = {}
     runtime = CanonicalizerRuntime()
@@ -2615,8 +2603,8 @@ async def test_hotword_mixed_invalid_list_filtered_and_matched() -> None:
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: ["Jarvis", "   ", None, 123],
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: ["Jarvis", "   ", None, 123],
     }
     entry.data = {}
     runtime = CanonicalizerRuntime()
@@ -2642,14 +2630,14 @@ def test_resolve_entry_hotword_options_fallback_chains() -> None:
     # 1. Options present and overrides data
     entry_both = MagicMock()
     entry_both.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: ["Jarvis", "Alexa"],
-        CONF_HOTWORD_MIN_CONFIDENCE: 0.92,
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: ["Jarvis", "Alexa"],
+        ConfigKey.HOTWORD_MIN_CONFIDENCE: 0.92,
     }
     entry_both.data = {
-        CONF_ENABLE_HOTWORD: False,
-        CONF_HOTWORD: ["OldHotword"],
-        CONF_HOTWORD_MIN_CONFIDENCE: 0.70,
+        ConfigKey.ENABLE_HOTWORD: False,
+        ConfigKey.HOTWORD: ["OldHotword"],
+        ConfigKey.HOTWORD_MIN_CONFIDENCE: 0.70,
     }
     enabled, hws, conf = resolve_entry_hotword_options(entry_both)
     assert enabled is True
@@ -2660,9 +2648,9 @@ def test_resolve_entry_hotword_options_fallback_chains() -> None:
     entry_data = MagicMock()
     entry_data.options = {}
     entry_data.data = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: ["Jarvis"],
-        CONF_HOTWORD_MIN_CONFIDENCE: 0.88,
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: ["Jarvis"],
+        ConfigKey.HOTWORD_MIN_CONFIDENCE: 0.88,
     }
     enabled, hws, conf = resolve_entry_hotword_options(entry_data)
     assert enabled is True
@@ -2716,9 +2704,9 @@ def test_resolve_entry_hotword_options_defensive_confidence_parsing() -> None:
     # 1. String float confidence is parsed cleanly
     entry_str = MagicMock()
     entry_str.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: ["Jarvis"],
-        CONF_HOTWORD_MIN_CONFIDENCE: "0.95",
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: ["Jarvis"],
+        ConfigKey.HOTWORD_MIN_CONFIDENCE: "0.95",
     }
     entry_str.data = {}
     _, _, conf = resolve_entry_hotword_options(entry_str)
@@ -2727,9 +2715,9 @@ def test_resolve_entry_hotword_options_defensive_confidence_parsing() -> None:
     # 2. Invalid string confidence falls back to default
     entry_inv = MagicMock()
     entry_inv.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: ["Jarvis"],
-        CONF_HOTWORD_MIN_CONFIDENCE: "invalid_not_a_number",
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: ["Jarvis"],
+        ConfigKey.HOTWORD_MIN_CONFIDENCE: "invalid_not_a_number",
     }
     entry_inv.data = {}
     _, _, conf = resolve_entry_hotword_options(entry_inv)
@@ -2738,9 +2726,9 @@ def test_resolve_entry_hotword_options_defensive_confidence_parsing() -> None:
     # 3. Out-of-bounds values are clamped to [0.0, 1.0]
     entry_high = MagicMock()
     entry_high.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: ["Jarvis"],
-        CONF_HOTWORD_MIN_CONFIDENCE: 2.5,
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: ["Jarvis"],
+        ConfigKey.HOTWORD_MIN_CONFIDENCE: 2.5,
     }
     entry_high.data = {}
     _, _, conf = resolve_entry_hotword_options(entry_high)
@@ -2748,9 +2736,9 @@ def test_resolve_entry_hotword_options_defensive_confidence_parsing() -> None:
 
     entry_low = MagicMock()
     entry_low.options = {
-        CONF_ENABLE_HOTWORD: True,
-        CONF_HOTWORD: ["Jarvis"],
-        CONF_HOTWORD_MIN_CONFIDENCE: -0.5,
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: ["Jarvis"],
+        ConfigKey.HOTWORD_MIN_CONFIDENCE: -0.5,
     }
     entry_low.data = {}
     _, _, conf = resolve_entry_hotword_options(entry_low)
@@ -2760,9 +2748,9 @@ def test_resolve_entry_hotword_options_defensive_confidence_parsing() -> None:
     for non_finite in (float("nan"), float("inf"), float("-inf")):
         entry_non_finite = MagicMock()
         entry_non_finite.options = {
-            CONF_ENABLE_HOTWORD: True,
-            CONF_HOTWORD: ["Jarvis"],
-            CONF_HOTWORD_MIN_CONFIDENCE: non_finite,
+            ConfigKey.ENABLE_HOTWORD: True,
+            ConfigKey.HOTWORD: ["Jarvis"],
+            ConfigKey.HOTWORD_MIN_CONFIDENCE: non_finite,
         }
         entry_non_finite.data = {}
         _, _, conf = resolve_entry_hotword_options(entry_non_finite)

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -13,16 +13,8 @@ from homeassistant.components.conversation.models import ConversationInput
 from homeassistant.core import Context, HomeAssistant
 
 from custom_components.assist_canonicalizer.const import (
-    CONVERSATION_INPUT_AGENT_ID_FIELD,
-    CONVERSATION_INPUT_AREA_CONTEXT_FIELD,
-    CONVERSATION_INPUT_CONTEXT_FIELD,
-    CONVERSATION_INPUT_CONVERSATION_ID_FIELD,
-    CONVERSATION_INPUT_DEVICE_ID_FIELD,
-    CONVERSATION_INPUT_EXTRA_SYSTEM_PROMPT_FIELD,
-    CONVERSATION_INPUT_LANGUAGE_FIELD,
     CONVERSATION_INPUT_OPTIONAL_FIELDS,
-    CONVERSATION_INPUT_SATELLITE_ID_FIELD,
-    CONVERSATION_INPUT_TEXT_FIELD,
+    ConversationInputField,
 )
 from custom_components.assist_canonicalizer.recognition import (
     _MAX_OBSERVED_VALUE_LENGTH,
@@ -37,16 +29,16 @@ def _conversation_input() -> ConversationInput:
     """Return a request populated with every supported context field."""
     signature = inspect.signature(ConversationInput)
     kwargs: dict[str, Any] = {
-        CONVERSATION_INPUT_TEXT_FIELD: "turn teh lamp on",
-        CONVERSATION_INPUT_CONTEXT_FIELD: Context(user_id="benchmark-user"),
-        CONVERSATION_INPUT_CONVERSATION_ID_FIELD: "recognition-request",
-        CONVERSATION_INPUT_DEVICE_ID_FIELD: "device-kitchen",
-        CONVERSATION_INPUT_LANGUAGE_FIELD: "en-US",
+        ConversationInputField.TEXT: "turn teh lamp on",
+        ConversationInputField.CONTEXT: Context(user_id="benchmark-user"),
+        ConversationInputField.CONVERSATION_ID: "recognition-request",
+        ConversationInputField.DEVICE_ID: "device-kitchen",
+        ConversationInputField.LANGUAGE: "en-US",
     }
     optional = {
-        CONVERSATION_INPUT_AGENT_ID_FIELD: "conversation.assist_canonicalizer",
-        CONVERSATION_INPUT_SATELLITE_ID_FIELD: "assist_satellite.kitchen",
-        CONVERSATION_INPUT_EXTRA_SYSTEM_PROMPT_FIELD: "stay local",
+        ConversationInputField.AGENT_ID: "conversation.assist_canonicalizer",
+        ConversationInputField.SATELLITE_ID: "assist_satellite.kitchen",
+        ConversationInputField.EXTRA_SYSTEM_PROMPT: "stay local",
     }
     kwargs |= {name: value for name, value in optional.items() if name in signature.parameters}
     return ConversationInput(**kwargs)
@@ -91,11 +83,11 @@ async def test_recognition_forwards_context_and_observes_intent_without_executio
     assert observation.required_context == ("domain",)
     assert observation.excluded_context == ("state",)
     assert set(observation.forwarded_context) >= {
-        CONVERSATION_INPUT_CONTEXT_FIELD,
-        CONVERSATION_INPUT_CONVERSATION_ID_FIELD,
-        CONVERSATION_INPUT_DEVICE_ID_FIELD,
-        CONVERSATION_INPUT_LANGUAGE_FIELD,
-        CONVERSATION_INPUT_AREA_CONTEXT_FIELD,
+        ConversationInputField.CONTEXT,
+        ConversationInputField.CONVERSATION_ID,
+        ConversationInputField.DEVICE_ID,
+        ConversationInputField.LANGUAGE,
+        ConversationInputField.AREA_CONTEXT,
     }
     recognize_trigger.assert_awaited_once()
     recognize_intent.assert_awaited_once()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -13,18 +13,11 @@ from voluptuous import Invalid
 
 from custom_components.assist_canonicalizer.candidate import Candidate
 from custom_components.assist_canonicalizer.const import (
-    ATTR_AGENT_ID,
-    CONF_FALLBACK_AGENT_ID,
-    CONF_MIN_CONFIDENCE,
-    CONF_MIN_MARGIN,
     DATA_RUNTIME,
     DOMAIN,
-    SERVICE_CLEAR_INDEX,
-    SERVICE_DIAGNOSTICS,
-    SERVICE_DUMP_CANDIDATES,
-    SERVICE_REBUILD_INDEX,
-    SERVICE_SET_FALLBACK_AGENT,
-    SERVICE_TEST_MATCH,
+    AttributeName,
+    ConfigKey,
+    ServiceName,
 )
 from custom_components.assist_canonicalizer.indexer import build_index
 from custom_components.assist_canonicalizer.ranking import RankedCandidate, ScoreBreakdown
@@ -57,20 +50,20 @@ def _as_hass(value: object) -> HomeAssistant:
 
 
 _EXPECTED_SERVICE_SCHEMAS = {
-    SERVICE_SET_FALLBACK_AGENT: SET_FALLBACK_AGENT_SCHEMA,
-    SERVICE_TEST_MATCH: TEST_MATCH_SCHEMA,
-    SERVICE_REBUILD_INDEX: REBUILD_INDEX_SCHEMA,
-    SERVICE_CLEAR_INDEX: CLEAR_INDEX_SCHEMA,
-    SERVICE_DIAGNOSTICS: DIAGNOSTICS_SCHEMA,
-    SERVICE_DUMP_CANDIDATES: DUMP_CANDIDATES_SCHEMA,
+    ServiceName.SET_FALLBACK_AGENT: SET_FALLBACK_AGENT_SCHEMA,
+    ServiceName.TEST_MATCH: TEST_MATCH_SCHEMA,
+    ServiceName.REBUILD_INDEX: REBUILD_INDEX_SCHEMA,
+    ServiceName.CLEAR_INDEX: CLEAR_INDEX_SCHEMA,
+    ServiceName.DIAGNOSTICS: DIAGNOSTICS_SCHEMA,
+    ServiceName.DUMP_CANDIDATES: DUMP_CANDIDATES_SCHEMA,
 }
 _EXPECTED_SERVICE_RESPONSE_SUPPORT = {
-    SERVICE_SET_FALLBACK_AGENT: SupportsResponse.OPTIONAL,
-    SERVICE_TEST_MATCH: SupportsResponse.ONLY,
-    SERVICE_REBUILD_INDEX: SupportsResponse.ONLY,
-    SERVICE_CLEAR_INDEX: SupportsResponse.ONLY,
-    SERVICE_DIAGNOSTICS: SupportsResponse.ONLY,
-    SERVICE_DUMP_CANDIDATES: SupportsResponse.ONLY,
+    ServiceName.SET_FALLBACK_AGENT: SupportsResponse.OPTIONAL,
+    ServiceName.TEST_MATCH: SupportsResponse.ONLY,
+    ServiceName.REBUILD_INDEX: SupportsResponse.ONLY,
+    ServiceName.CLEAR_INDEX: SupportsResponse.ONLY,
+    ServiceName.DIAGNOSTICS: SupportsResponse.ONLY,
+    ServiceName.DUMP_CANDIDATES: SupportsResponse.ONLY,
 }
 
 
@@ -126,21 +119,22 @@ class _ServiceRegistrationRecorder:
 
     def __init__(self) -> None:
         """Initialize service callback storage."""
-        self.registered_services: dict[str, Any] = {}
-        self.registration_kwargs: dict[str, dict[str, Any]] = {}
+        self.registered_services: dict[ServiceName | str, Any] = {}
+        self.registration_kwargs: dict[ServiceName | str, dict[str, Any]] = {}
 
     def __call__(
         self,
         domain: str,
-        service: str,
+        service: ServiceName | str,
         callback: Any,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         """Mock service registration callback."""
         assert domain == DOMAIN, f"Expected domain {DOMAIN}, got {domain}"
-        assert kwargs.get("schema") is _EXPECTED_SERVICE_SCHEMAS[service]
-        assert kwargs.get("supports_response") is _EXPECTED_SERVICE_RESPONSE_SUPPORT[service]
+        service_name = ServiceName(service)
+        assert kwargs.get("schema") is _EXPECTED_SERVICE_SCHEMAS[service_name]
+        assert kwargs.get("supports_response") is _EXPECTED_SERVICE_RESPONSE_SUPPORT[service_name]
         self.registered_services[service] = callback
         self.registration_kwargs[service] = dict(kwargs)
 
@@ -162,8 +156,8 @@ async def test_set_fallback_agent_service_reports_config_entry_change(
     runtime = CanonicalizerRuntime()
     entry = HassMockConfigEntry(
         domain=DOMAIN,
-        options={CONF_MIN_CONFIDENCE: 0.7},
-        data={CONF_FALLBACK_AGENT_ID: "old_agent"},
+        options={ConfigKey.MIN_CONFIDENCE: 0.7},
+        data={ConfigKey.FALLBACK_AGENT_ID: "old_agent"},
     )
     entry.add_to_hass(hass)
     hass.data[DOMAIN] = {
@@ -172,7 +166,7 @@ async def test_set_fallback_agent_service_reports_config_entry_change(
             "entry": entry,
         }
     }
-    call = MockServiceCall({ATTR_AGENT_ID: "new_agent"})
+    call = MockServiceCall({AttributeName.AGENT_ID: "new_agent"})
 
     with patch(
         "custom_components.assist_canonicalizer.services.async_get_agent",
@@ -182,16 +176,16 @@ async def test_set_fallback_agent_service_reports_config_entry_change(
         unchanged_result = await _handle_set_fallback_agent(_as_hass(hass), cast(ServiceCall, call))
 
     assert result == {
-        CONF_FALLBACK_AGENT_ID: "new_agent",
+        ConfigKey.FALLBACK_AGENT_ID: "new_agent",
         "previous_fallback_agent_id": "old_agent",
         "changed": True,
     }
     assert dict(entry.options) == {
-        CONF_MIN_CONFIDENCE: 0.7,
-        CONF_FALLBACK_AGENT_ID: "new_agent",
+        ConfigKey.MIN_CONFIDENCE: 0.7,
+        ConfigKey.FALLBACK_AGENT_ID: "new_agent",
     }
     assert unchanged_result == {
-        CONF_FALLBACK_AGENT_ID: "new_agent",
+        ConfigKey.FALLBACK_AGENT_ID: "new_agent",
         "previous_fallback_agent_id": "new_agent",
         "changed": False,
     }
@@ -230,7 +224,7 @@ async def test_set_fallback_agent_service_rejects_invalid_targets(
     ):
         await _handle_set_fallback_agent(
             _as_hass(hass),
-            cast(ServiceCall, MockServiceCall({ATTR_AGENT_ID: agent_id})),
+            cast(ServiceCall, MockServiceCall({AttributeName.AGENT_ID: agent_id})),
         )
 
     hass.config_entries.async_update_entry.assert_not_called()
@@ -238,9 +232,11 @@ async def test_set_fallback_agent_service_rejects_invalid_targets(
 
 def test_set_fallback_agent_schema_trims_and_rejects_empty_ids() -> None:
     """Normalize hand-authored action data before resolving an agent."""
-    assert SET_FALLBACK_AGENT_SCHEMA({ATTR_AGENT_ID: "  agent-id  "}) == {ATTR_AGENT_ID: "agent-id"}
+    assert SET_FALLBACK_AGENT_SCHEMA({AttributeName.AGENT_ID: "  agent-id  "}) == {
+        AttributeName.AGENT_ID: "agent-id"
+    }
     with pytest.raises(Invalid):
-        SET_FALLBACK_AGENT_SCHEMA({ATTR_AGENT_ID: "  "})
+        SET_FALLBACK_AGENT_SCHEMA({AttributeName.AGENT_ID: "  "})
 
 
 @pytest.mark.asyncio
@@ -288,7 +284,7 @@ async def test_handle_test_match_entry_none_and_data_fallback() -> None:
 
     # Case 2: entry is not None, options is empty, fallback to data
     entry_data = MockConfigEntry(
-        options={}, data={CONF_MIN_CONFIDENCE: 0.10, CONF_MIN_MARGIN: 0.01}
+        options={}, data={ConfigKey.MIN_CONFIDENCE: 0.10, ConfigKey.MIN_MARGIN: 0.01}
     )
     hass_data = MockHass(runtime, entry=entry_data)
     result_data = await _handle_test_match(_as_hass(hass_data), cast(ServiceCall, call))
@@ -657,31 +653,31 @@ async def test_async_services_dispatch() -> None:
 
         call = MockServiceCall({})
 
-        res_set_fallback = await recorder.registered_services[SERVICE_SET_FALLBACK_AGENT](call)
+        res_set_fallback = await recorder.registered_services[ServiceName.SET_FALLBACK_AGENT](call)
         assert res_set_fallback == {"status": "updated"}
         mock_set_fallback.assert_called_once_with(hass, call)
 
         # Test handle_test_match
-        res_test = await recorder.registered_services[SERVICE_TEST_MATCH](call)
+        res_test = await recorder.registered_services[ServiceName.TEST_MATCH](call)
         assert res_test == {"status": "tested"}
         mock_test.assert_called_once_with(hass, call)
 
         # Test handle_rebuild_index
-        res_rebuild = await recorder.registered_services[SERVICE_REBUILD_INDEX](call)
+        res_rebuild = await recorder.registered_services[ServiceName.REBUILD_INDEX](call)
         assert res_rebuild == {"status": "rebuilt"}
         mock_rebuild.assert_called_once_with(hass, call)
 
-        res_clear = await recorder.registered_services[SERVICE_CLEAR_INDEX](call)
+        res_clear = await recorder.registered_services[ServiceName.CLEAR_INDEX](call)
         assert res_clear == {"status": "cleared"}
         mock_clear.assert_called_once_with(hass, call)
 
         # Test handle_dump_candidates
-        res_dump = await recorder.registered_services[SERVICE_DUMP_CANDIDATES](call)
+        res_dump = await recorder.registered_services[ServiceName.DUMP_CANDIDATES](call)
         assert res_dump == {"status": "dumped"}
         mock_dump.assert_called_once_with(hass, call)
 
         # Test handle_diagnostics
-        res_diagnostics = await recorder.registered_services[SERVICE_DIAGNOSTICS](call)
+        res_diagnostics = await recorder.registered_services[ServiceName.DIAGNOSTICS](call)
         assert res_diagnostics == {"status": "diagnosed"}
         mock_diagnostics.assert_called_once_with(hass, call)
 
@@ -733,7 +729,7 @@ async def test_services_exception_wrapping() -> None:
     ):
         await _handle_set_fallback_agent(
             _as_hass(hass),
-            cast(ServiceCall, MockServiceCall({ATTR_AGENT_ID: "other_agent"})),
+            cast(ServiceCall, MockServiceCall({AttributeName.AGENT_ID: "other_agent"})),
         )
 
     # 3. _handle_rebuild_index raising error

--- a/uv.lock
+++ b/uv.lock
@@ -574,30 +574,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.79"
+version = "1.43.80"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/1b/d5091a11b37633c987015516fb87e1330c5e97c42ab2d6527b778bdc537a/boto3-1.43.79.tar.gz", hash = "sha256:a36b4209a8170f7f8d2c19b36f350808f313b178939c9e5df0a8f683717a6d9c", size = 112682, upload-time = "2026-08-24T19:30:13.676Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/97/9ef9b949f253b197c813c57ab58578572d20dbacedceb5a5f4516ea628cb/boto3-1.43.80.tar.gz", hash = "sha256:384d522e2ce722266afceea8ab3e618e16695b358ebe32b45e0a2109fcd53a28", size = 112674, upload-time = "2026-08-25T20:38:34.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/90/eef59b9b64442b4c966b027e8db407f59d99200b82b71316fc4466562a53/boto3-1.43.79-py3-none-any.whl", hash = "sha256:4c2381cf99abf749c82762a636337f4aba4800fda6525412fcae2bebe4f72748", size = 140025, upload-time = "2026-08-24T19:30:12.331Z" },
+    { url = "https://files.pythonhosted.org/packages/79/66/415da75a7846e46156a4746aae72a8e4b0c4d263e2c2559a083ad247ba39/boto3-1.43.80-py3-none-any.whl", hash = "sha256:26afe3b950ca1cc722c7fa5544991c222919c98355f82300a55b6315a2c4995e", size = 140024, upload-time = "2026-08-25T20:38:33.021Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.79"
+version = "1.43.80"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/90/e67b32a388f5be5fa84adb92eb4be4d9bbe51a70fd4a208222bf6d428972/botocore-1.43.79.tar.gz", hash = "sha256:dcc0a97b65affcef80e0499745d2e6a5d120253c11b8727b8227df44ab3e958f", size = 15988663, upload-time = "2026-08-24T19:30:09.145Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/94/de291ad81495365682722efa9397c54c7b666f7bf1ae4064d26e40a55296/botocore-1.43.80.tar.gz", hash = "sha256:c021e60df26d17e9a8db05fa5071669449c8fd15e0fb4374f56a6c17d553f89b", size = 16003031, upload-time = "2026-08-25T20:38:29.86Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/d5/f34b9313ca9db131ad7d74156e3459694ced17f81233a248bd00eb6d67b1/botocore-1.43.79-py3-none-any.whl", hash = "sha256:19b2c772ea2590d0baad6ae004a0e478cf2c982e0e6a39c8e2f882d9b2981445", size = 15680587, upload-time = "2026-08-24T19:30:04.397Z" },
+    { url = "https://files.pythonhosted.org/packages/64/93/7bba357266450f7d3e3075ee4d2f1e1d96c1617e40d8065c558485baed78/botocore-1.43.80-py3-none-any.whl", hash = "sha256:461bce2159eadd758d0651d2a11dced3450169383e6ca8ef65f5c250f8b7ebd4", size = 15695640, upload-time = "2026-08-25T20:38:26.76Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Replace scattered string constants with named StrEnum groups across the integration and its tests.

Enhancements:
- Group configuration keys, service names, attributes, and conversation input fields into named StrEnum types while preserving their external string values.
- Use typed service response payloads and enum-backed identifiers throughout configuration, conversation, recognition, and service handling.
- Serialize candidate source values consistently through their enum values.

Tests:
- Update unit and integration tests to use the new enum groups while continuing to validate Home Assistant service, configuration-flow, and conversation contracts.

Chores:
- Remove the former module-level constant aliases in favor of the grouped enums.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized configuration, service, attribute, and conversation field identifiers into structured enums.
  * Preserved existing configuration, conversation handling, service behavior, and fallback settings.
  * Improved consistency when serializing candidates and handling area context.

* **Tests**
  * Updated compatibility, conversation, recognition, and service coverage to use the new identifier structure.
  * Existing behavior and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->