### PR TITLE
Strip the hot word prefix before routing to fallback agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ People do not always phrase the same request in the same way. Word order, filler
 - **Automatic Candidate Index Building**: Builds language-specific indexes from supported Home Assistant sources: built-in intents, custom sentence YAML files, exposed entity names and aliases, area and floor registries, and dynamically expanded slot values.
 - **On-Disk Candidate Persistence**: Stores canonical candidate lists in Home Assistant storage. Later rebuilds can reuse these lists instead of parsing every sentence template and YAML file again.
 - **Configurable Confidence Gates**: Fine-tune match acceptance with **Minimum Match Confidence** and **Base Confidence Margin** thresholds. Exact lexical matches and other strong-evidence policies can reduce the required margin; if no earlier relaxation applies, competing actions, including known opposing actions, must clear the full configured margin.
-- **Hot Word Bypass**: Optionally specify custom hot words (e.g. `"Jarvis"`, `"Hey Jarvis"`) to bypass all canonicalization and candidate ranking steps and directly route commands untouched to your configured fallback agent (such as an LLM).
+- **Hot Word Bypass**: Optionally specify custom hot words (e.g. `"Jarvis"`, `"Hey Jarvis"`). When asking difficult questions, complex inquiries, or unclear commands, this prevents the ranking system from accidentally misclassifying them into mismatched or unintended smart home commands, stripping the hot word prefix and routing the clean prompt directly to your configured fallback conversation agent (such as an LLM agent).
 - **Live Recognition Preflight and Bounded Recovery**: Verifies whether a matched sentence is executable using Home Assistant's native intent parser before triggering an action. The engine tests up to three high-confidence candidates before falling back and allows one recovery attempt if a command is rejected before the handler runs.
 - **Developer Tools Actions**: Six actions (`set_fallback_agent`, `test_match`, `rebuild_index`, `clear_index`, `diagnostics`, and `dump_candidates`) provide dynamic fallback routing, ranking details, index summaries, diagnostics, and manual index lifecycle controls from Home Assistant's standard Actions panel.
 - **Per-Language Isolation**: Maintains a dedicated candidate index for each language, with automatic language variant matching against Home Assistant's supported language list. Slot values are dynamically expanded per language.
@@ -91,7 +91,7 @@ People do not always phrase the same request in the same way. Word order, filler
 3. Select the **Fallback Conversation Agent**. When the canonicalizer cannot safely complete a request, it sends the original text to this agent for a second chance. For the best chance of recovery, choose an agent that interprets language differently, such as an LLM-based conversation agent. The built-in Home Assistant agent is also supported, but it may encounter the same limitation that led to fallback.
 4. Set the **Minimum Match Confidence**. A candidate's weighted final score must meet this threshold to be accepted. Start with the default and use **Test Match** to inspect real scores before adjusting it.
 5. Set the **Base Confidence Margin**. This defines the normal required gap in scores between the top match and the next best alternative (with a different intent), preventing execution when a command is ambiguous. Exact lexical matches and other strong-evidence policies can reduce or bypass this requirement before action competition is evaluated. If no earlier relaxation applies, competing actions, including known opposing actions such as turn on vs. turn off, must clear the full configured value.
-6. _(Optional)_ Configure **Hot Word Bypass**: Enable the toggle and add your custom trigger words or phrases (e.g. `"Jarvis"`, `"Hey Jarvis"`). Commands matching any configured hot word prefix with high confidence (default $\ge 0.85$) bypass canonicalization ranking and are forwarded directly as untouched text to your fallback agent.
+6. _(Optional)_ Configure **Hot Word Bypass**: Enable the toggle and add your custom trigger words or phrases (e.g. `"Jarvis"`, `"Hey Jarvis"`). For difficult questions, complex inquiries, or open-ended conversational prompts, matching a hot word prefix with high confidence (default $\ge 0.85$) prevents the ranking system from misclassifying them as unintended smart home actions, stripping the prefix and directly forwarding the clean command to your fallback LLM agent.
 7. Go to **Settings** > **Voice assistants** and open your Assist pipeline. Under **Conversation agents**, select **Assist Canonicalizer** from the agent list.
 
 > [!IMPORTANT]
@@ -103,11 +103,18 @@ People do not always phrase the same request in the same way. Word order, filler
 
 ## How It Works
 
-Home Assistant gives its built-in HassIL agent the first chance when the Assist pipeline has `prefer_local_intents` enabled. When that option is disabled, Assist Canonicalizer supplies the equivalent HassIL-first shortcut. Canonicalization begins only if HassIL cannot handle the original text:
+How requests reach Assist Canonicalizer depends on your Assist pipeline's **prefer_local_intents** setting:
+
+- **When `prefer_local_intents` is enabled (Home Assistant default)**: Home Assistant tests its built-in HassIL parser first. Exact matches to built-in sentence templates are executed directly by Home Assistant without invoking this integration. Any queries that HassIL cannot match (including normal smart home commands with typos, reordered words, or paraphrased phrasing, as well as questions prefixed with a custom hot word like `"Jarvis, what is quantum physics?"`) are handed off to Assist Canonicalizer to be canonicalized or forwarded to fallback.
+- **When `prefer_local_intents` is disabled**: Home Assistant routes all queries directly to Assist Canonicalizer. The integration evaluates **Hot Word Bypass** first, runs an internal shortcut to HassIL for standard commands, and proceeds to multi-signal lexical ranking for everything else.
+
+Inside Assist Canonicalizer, the execution flow is as follows:
 
 ```mermaid
 flowchart TD
-    A[User Input] --> L{Can HassIL handle the original input?}
+    A[User Input] --> HW{Hot word bypass matched?}
+    HW -->|Yes| HW_G[Fallback Agent Receives Stripped Prompt]
+    HW -->|No| L{Can HassIL handle the original input?}
     L -->|Yes| H[Return Home Assistant Result]
     L -->|No| B[Text Normalization]
     B --> C[Index Lookup]
@@ -129,32 +136,34 @@ flowchart TD
     K -->|Failure| G
 ```
 
-1. **HassIL First**: With `prefer_local_intents` enabled, Home Assistant tries HassIL before falling back to Assist Canonicalizer. With it disabled, the pipeline delegates directly to Assist Canonicalizer, which sends the unchanged request to HassIL as a shortcut. The integration skips its shortcut when Home Assistant has already performed the local-intent pass. If HassIL succeeds, its result is returned immediately and the remaining steps are skipped.
+1. **Hot Word Bypass (Optional)**: When enabled, incoming queries are evaluated against configured custom hot words using fuzzy prefix matching (default threshold $\ge 0.85$, with diacritic-tolerant comparison). When a question is difficult or a command is unclear, this prevents the ranking system from misclassifying it as a mismatched or unintended smart home action, bypassing local intent matching entirely, cleanly stripping the hot word prefix and leading punctuation, and forwarding the prompt directly to your fallback LLM (recording `hotword_matched` in diagnostics). If only the hot word is spoken, the original text is preserved.
 
-2. **Text Normalization**: The input is NFKC-normalized, casefolded, stripped of punctuation, and collapsed to a consistent whitespace form. The same process is applied to the input and candidate sentences.
+2. **HassIL First**: When `prefer_local_intents` is enabled (the default in Home Assistant), commands are redirected to HassIL before being handled by this integration. When `prefer_local_intents` is turned off, this integration simulates the same logic by using a shortcut to send the raw command directly to HassIL. If HassIL succeeds, its result is returned immediately and canonicalization is skipped; if HassIL cannot handle the input, canonicalization begins.
 
-3. **Index Lookup**: The normalized query is matched against a pre-built candidate index for the active language. The index contains candidates sourced from:
+3. **Text Normalization**: The input is NFKC-normalized, casefolded, stripped of punctuation, and collapsed to a consistent whitespace form. The same process is applied to the input and candidate sentences.
+
+4. **Index Lookup**: The normalized query is matched against a pre-built candidate index for the active language. The index contains candidates sourced from:
    - **Built-in Intents**: Every fixed sentence and bounded template expansion from Home Assistant's sentence configuration for the language.
    - **Custom Sentences**: Sentences defined in `custom_sentences/<lang>/` YAML files, `configuration.yaml` intent scripts, or sentence automations created via the UI.
    - **Registry Entities**: Exposed entity names and aliases from the entity registry.
    - **Areas and Floors**: Area and floor names from the area and floor registries.
 
-4. **Multi-Signal Ranking**: Each candidate is scored through four independent signals, then combined into a weighted final score:
+5. **Multi-Signal Ranking**: Each candidate is scored through four independent signals, then combined into a weighted final score:
    - **Word Similarity**: Measures how closely the words and their order match, handles typos, reordered words, and partial matches.
    - **Character Pattern Matching**: Compares overlapping 3-letter chunks between your input and each candidate, catching spelling variations and similar-looking words.
    - **Keyword Relevance**: Weighs how important each word is across all candidates, giving more credit to distinctive words that appear in your input.
    - **Intent Context**: Rewards candidates whose intent type (e.g., turning on a light, setting a temperature) aligns with the top matches, preventing nonsensical pairings.
 
-5. **Confidence Gate**: Evaluates the top candidate against your configured thresholds:
+6. **Confidence Gate**: Evaluates the top candidate against your configured thresholds:
    - **Confidence Floor**: The candidate's final score must clear the `min_confidence` threshold.
    - **Dynamic Margin**: The candidate normally must lead its next best meaningful competitor (representing a different intent) by the configured `min_margin`. Exact lexical matches can bypass that margin, and other strong-evidence policies can reduce it before action competition is evaluated. If none of those earlier policies applies, competing actions, including known opposing pairs such as turn on/off, open/close, and lock/unlock, must clear the full configured margin. Gating decisions and effective margins are fully visible via diagnostics.
 
-6. **Live Preflight, Execution, and Bounded Recovery**: Once a candidate passes the confidence gate, it undergoes a multi-stage validation and execution process:
+7. **Live Preflight, Execution, and Bounded Recovery**: Once a candidate passes the confidence gate, it undergoes a multi-stage validation and execution process:
    - **Live Recognition Preflight**: The candidate text is dry-run through Home Assistant's native intent recognition to verify it is executable. If it is invalid (e.g., references a non-existent area or device), the candidate is discarded, and the engine re-evaluates the remaining list (testing up to three distinct alternatives). If none are valid, it falls back to the configured fallback agent.
    - **Live Execution**: If the preflight check succeeds, the command is sent to Home Assistant's built-in conversation agent (HassIL) for execution.
    - **Bounded Post-Execution Recovery**: If execution is rejected before the intent handler begins processing (returning `no_intent_match`, or `no_valid_targets` due to unmatched entities), the integration can attempt a one-time recovery. It filters out duplicate commands and tries the next best candidate that still meets the confidence criteria. Errors occurring inside the intent handler itself do not trigger recovery and will result in fallback.
 
-7. **Fallback**: If ranking does not produce a safe candidate, recovery is not eligible, or execution fails, the integration forwards the original input to your configured fallback conversation agent.
+8. **Fallback**: If hot word bypass is triggered, the integration forwards the stripped prompt to your configured fallback conversation agent. For all other fallback paths (when ranking does not produce a safe candidate, recovery is not eligible, or execution fails), the integration forwards the original input.
 
 ---
 
@@ -321,6 +330,7 @@ When a query **falls back**, the reason is recorded in diagnostics as one of:
 
 | Reason                 | Meaning                                                                                                  |
 | ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| `hotword_matched`      | The input matched a configured hot word prefix and was forwarded directly to the fallback agent          |
 | `low_confidence`       | No candidate met the `min_confidence` threshold                                                          |
 | `low_margin`           | The top candidate and the next candidate with a different intent scored too closely (below `min_margin`) |
 | `empty_index`          | No index exists for the active language                                                                  |
@@ -340,9 +350,10 @@ Before changing thresholds, check the runtime state and candidate coverage, then
 
 **The canonicalizer always falls back and never matches.**
 
-1. Run the **Diagnostics** action and check `last_fallback_reason`. If it's `empty_index`, the index hasn't been built yet. Indexes are proactively warmed up at startup/reload for all configured Assist pipeline languages. If `empty_index` still appears, the warmup may have been skipped (no pipelines configured, no default language available), or the background build hasn't completed yet. You can force a rebuild with the **Rebuild Index** action.
-2. If the reason is `low_confidence`, your `min_confidence` threshold may be too high. Try lowering it in the integration options. Use **Test Match** with sample sentences to see actual scores.
-3. If the reason is `validation_failed`, the selected command failed the live preflight check, or both execution and recovery attempts failed. Use **Test Match** to analyze scoring, and **Dump Candidates** to inspect the registered commands for your language.
+1. Run the **Diagnostics** action and check `last_fallback_reason`. If it's `hotword_matched`, the query matched a configured hot word prefix and was intentionally routed directly to the fallback agent (bypassing the main canonicalization or ranking flow).
+2. If it's `empty_index`, the index hasn't been built yet. Indexes are proactively warmed up at startup/reload for all configured Assist pipeline languages. If `empty_index` still appears, the warmup may have been skipped (no pipelines configured, no default language available), or the background build hasn't completed yet. You can force a rebuild with the **Rebuild Index** action.
+3. If the reason is `low_confidence`, your `min_confidence` threshold may be too high. Try lowering it in the integration options. Use **Test Match** with sample sentences to see actual scores.
+4. If the reason is `validation_failed`, the selected command failed the live preflight check, or both execution and recovery attempts failed. Use **Test Match** to analyze scoring, and **Dump Candidates** to inspect the registered commands for your language.
 
 **My custom sentences aren't being recognized.**
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -54,7 +54,7 @@ Trong thực tế, cùng một yêu cầu có thể được diễn đạt theo 
 - **Tự động xây dựng chỉ mục ứng viên (Automatic Candidate Index Building)**: Tạo chỉ mục riêng cho từng ngôn ngữ từ các nguồn Home Assistant được hỗ trợ: ý định tích hợp sẵn, tệp YAML chứa mẫu câu tùy chỉnh, tên và bí danh thực thể, sổ đăng ký khu vực và tầng, cùng các giá trị tham số (slot) được mở rộng động.
 - **Lưu ứng viên trên ổ đĩa (On-Disk Candidate Persistence)**: Lưu danh sách ứng viên chuẩn trong hệ thống lưu trữ của Home Assistant. Các lần xây dựng sau có thể dùng lại danh sách này thay vì phân tích lại toàn bộ mẫu câu và tệp YAML.
 - **Bộ lọc độ tin cậy có thể cấu hình (Configurable Confidence Gates)**: Điều chỉnh việc chấp nhận kết quả qua hai ngưỡng **Độ tin cậy tối thiểu (Minimum Match Confidence)** và **Khoảng cách độ tin cậy cơ sở (Base Confidence Margin)**. Kết quả khớp từ vựng chính xác và các chính sách có bằng chứng mạnh khác có thể giảm khoảng cách yêu cầu. Nếu không có chính sách nới lỏng phù hợp, các hành động cạnh tranh, kể cả hành động đối nghịch đã biết, phải đạt mức chênh lệch đầy đủ theo cấu hình.
-- **Bỏ qua bằng từ khóa nóng (Hot Word Bypass)**: Tùy chọn chỉ định từ khóa nóng (ví dụ `"Jarvis"`, `"Hey Jarvis"`) để bỏ qua toàn bộ các bước chuẩn hóa và xếp hạng ứng viên, chuyển thẳng nguyên văn câu lệnh tới tác nhân dự phòng đã cấu hình (chẳng hạn như LLM).
+- **Bỏ qua bằng từ khóa nóng (Hot Word Bypass)**: Tùy chọn chỉ định từ khóa nóng (ví dụ `"Jarvis"`, `"Hey Jarvis"`). Khi gặp câu hỏi khó, yêu cầu phức tạp hoặc câu lệnh chưa rõ ràng, tính năng này giúp ngăn hệ thống xếp hạng nhận diện sai lệch thành các lệnh nhà thông minh ngoài ý muốn, tự động cắt bỏ tiền tố từ khóa nóng và chuyển câu lệnh sạch tới tác nhân hội thoại dự phòng đã cấu hình (chẳng hạn như tác nhân LLM).
 - **Tiền kiểm nhận diện theo trạng thái thực tế và khôi phục có giới hạn (Live Recognition Preflight and Bounded Recovery)**: Xác minh câu lệnh chuẩn bằng bộ nhận diện ý định tích hợp sẵn của Home Assistant trước khi thực thi. Hệ thống thử tối đa ba ứng viên có độ tin cậy cao trước khi chuyển sang dự phòng, đồng thời cho phép một lần khôi phục nếu lệnh bị từ chối trước khi bộ xử lý ý định chạy.
 - **Hành động dành cho nhà phát triển**: Sáu hành động `set_fallback_agent`, `test_match`, `rebuild_index`, `clear_index`, `diagnostics` và `dump_candidates` cho phép thay đổi tuyến dự phòng, xem điểm xếp hạng, thông tin chỉ mục, dữ liệu chẩn đoán và quản lý vòng đời chỉ mục ngay trong bảng Hành động của Home Assistant.
 - **Chỉ mục riêng theo ngôn ngữ**: Quản lý độc lập chỉ mục cho từng ngôn ngữ và tự động đối chiếu biến thể ngôn ngữ với danh sách Home Assistant hỗ trợ.
@@ -91,7 +91,7 @@ Trong thực tế, cùng một yêu cầu có thể được diễn đạt theo 
 3. Chọn **Tác nhân hội thoại dự phòng (Fallback Conversation Agent)**. Khi Assist Canonicalizer không thể xử lý yêu cầu một cách an toàn, bộ tích hợp sẽ chuyển nguyên văn yêu cầu tới tác nhân này. Để tăng khả năng khôi phục, hãy chọn một tác nhân có cách diễn giải ngôn ngữ khác, chẳng hạn như tác nhân sử dụng LLM. Tác nhân mặc định của Home Assistant vẫn được hỗ trợ, nhưng có thể gặp lại chính hạn chế đã khiến yêu cầu chuyển sang dự phòng.
 4. Cấu hình **Độ tin cậy tối thiểu (Minimum Match Confidence)**: Điểm tổng hợp có trọng số của ứng viên phải đạt ngưỡng này mới được chấp nhận. Bạn nên bắt đầu với giá trị mặc định và dùng **Test Match** để xem điểm thực tế trước khi điều chỉnh.
 5. Cấu hình **Khoảng cách độ tin cậy cơ sở (Base Confidence Margin)**: Xác định mức chênh lệch điểm thông thường giữa kết quả cao nhất và lựa chọn phù hợp tiếp theo thuộc ý định khác, giúp tránh thực thi khi câu lệnh còn mơ hồ. Kết quả khớp từ vựng chính xác và các chính sách có bằng chứng mạnh khác có thể giảm hoặc bỏ qua yêu cầu này trước khi hệ thống đánh giá cạnh tranh giữa các hành động. Nếu không có chính sách nới lỏng phù hợp, các hành động cạnh tranh, kể cả cặp đối nghịch như bật và tắt, phải đạt mức chênh lệch đầy đủ theo cấu hình.
-6. _(Tùy chọn)_ Cấu hình **Bỏ qua bằng từ khóa nóng (Hot Word Bypass)**: Bật tính năng và thêm các từ khóa nóng tùy chỉnh (ví dụ `"Jarvis"`, `"Hey Jarvis"`). Khi câu lệnh có tiền tố khớp với bất kỳ từ khóa nóng nào ở độ tin cậy cao (mặc định $\ge 0.85$), hệ thống sẽ bỏ qua bước xếp hạng chuẩn hóa và chuyển trực tiếp nguyên văn câu lệnh đến tác nhân dự phòng.
+6. _(Tùy chọn)_ Cấu hình **Bỏ qua bằng từ khóa nóng (Hot Word Bypass)**: Bật tính năng và thêm các từ khóa nóng tùy chỉnh (ví dụ `"Jarvis"`, `"Hey Jarvis"`). Khi gặp các câu hỏi khó, câu lệnh phức tạp hoặc đàm thoại mở, tiền tố khớp từ khóa nóng ở độ tin cậy cao (mặc định $\ge 0.85$) sẽ ngăn hệ thống phân loại nhầm thành các hành động điều khiển thiết bị ngoài ý muốn, cắt bỏ tiền tố từ khóa nóng và chuyển thẳng câu lệnh tới tác nhân LLM dự phòng.
 7. Vào **Cài đặt (Settings)** > **Trợ lý giọng nói (Voice assistants)** và mở pipeline Assist của bạn. Tại mục **Tác nhân hội thoại (Conversation agents)**, chọn **Assist Canonicalizer**.
 
 > [!IMPORTANT]
@@ -103,11 +103,18 @@ Trong thực tế, cùng một yêu cầu có thể được diễn đạt theo 
 
 ## Cách hoạt động
 
-Khi pipeline Assist bật `prefer_local_intents`, Home Assistant để tác nhân HassIL tích hợp sẵn thử xử lý yêu cầu trước. Khi tùy chọn này bị tắt, Assist Canonicalizer cung cấp shortcut ưu tiên HassIL tương đương. Quá trình chuẩn hóa chỉ bắt đầu khi HassIL không xử lý được văn bản gốc:
+Cách các câu lệnh được chuyển đến Assist Canonicalizer phụ thuộc vào tùy chọn **prefer_local_intents** trong pipeline Assist của bạn:
+
+- **Khi bật `prefer_local_intents` (mặc định trong Home Assistant)**: Home Assistant sẽ thử xử lý bằng bộ nhận diện HassIL tích hợp sẵn trước. Các câu lệnh khớp chính xác mẫu câu tích hợp sẵn sẽ được Home Assistant thực thi ngay mà không cần gọi đến bộ tích hợp này. Mọi câu lệnh mà HassIL không khớp được (bao gồm cả các lệnh điều khiển thông thường bị lỗi chính tả, thay đổi vị trí từ, diễn đạt tự do, cũng như các câu hỏi có tiền tố từ khóa nóng như `"Jarvis, giải thích thuyết tương đối"`) sẽ được chuyển sang Assist Canonicalizer để chuẩn hóa hoặc chuyển tiếp dự phòng.
+- **Khi tắt `prefer_local_intents`**: Home Assistant chuyển thẳng toàn bộ câu lệnh tới Assist Canonicalizer. Khi đó, bộ tích hợp sẽ kiểm tra **Bỏ qua bằng từ khóa nóng (Hot Word Bypass)** trước tiên, chạy một shortcut tới HassIL cho các câu lệnh chuẩn, và thực hiện xếp hạng chuẩn hóa đa tín hiệu cho các trường hợp còn lại.
+
+Bên trong Assist Canonicalizer, luồng xử lý diễn ra như sau:
 
 ```mermaid
 flowchart TD
-    A[Nhập liệu từ người dùng] --> L{HassIL xử lý được yêu cầu gốc?}
+    A[Nhập liệu từ người dùng] --> HW{Khớp từ khóa nóng bỏ qua?}
+    HW -->|Có| HW_G[Tác nhân dự phòng nhận câu lệnh đã cắt tiền tố]
+    HW -->|Không| L{HassIL xử lý được yêu cầu gốc?}
     L -->|Có| H[Trả về kết quả từ Home Assistant]
     L -->|Không| B[Chuẩn hóa văn bản]
     B --> C[Tra cứu chỉ mục]
@@ -129,32 +136,34 @@ flowchart TD
     K -->|Thất bại| G
 ```
 
-1. **Ưu tiên HassIL**: Khi bật `prefer_local_intents`, Home Assistant thử HassIL trước khi chuyển sang Assist Canonicalizer. Khi tắt tùy chọn này, pipeline chuyển thẳng đến Assist Canonicalizer và bộ tích hợp gửi nguyên văn yêu cầu đến HassIL dưới dạng shortcut. Bộ tích hợp bỏ qua shortcut khi Home Assistant đã thực hiện lượt nhận diện ý định cục bộ. Nếu HassIL xử lý thành công, kết quả được trả về ngay và các bước còn lại được bỏ qua.
+1. **Bỏ qua bằng từ khóa nóng (Tùy chọn)**: Khi được bật, văn bản đầu vào được so khớp tiền tố với danh sách từ khóa nóng tùy chỉnh bằng so khớp mờ (ngưỡng tin cậy mặc định $\ge 0.85$, hỗ trợ bỏ dấu phụ). Khi gặp câu hỏi khó hoặc câu lệnh chưa rõ ràng, tính năng này ngăn hệ thống xếp hạng phân loại nhầm thành các lệnh điều khiển thiết bị ngoài ý muốn, bỏ qua hoàn toàn bước so khớp ý định cục bộ, tự động cắt bỏ tiền tố từ khóa nóng cùng dấu câu đầu dòng và chuyển câu lệnh tới LLM dự phòng (ghi nhận lý do `hotword_matched` trong chẩn đoán). Nếu người dùng chỉ nói riêng từ khóa nóng, văn bản gốc sẽ được giữ nguyên.
 
-2. **Chuẩn hóa văn bản (Text Normalization)**: Chuẩn hóa ký tự theo NFKC, chuyển chữ hoa thành chữ thường theo Unicode, loại bỏ dấu câu và thu gọn khoảng trắng. Quy trình giống nhau được áp dụng cho câu lệnh đầu vào và các câu ứng viên.
+2. **Ưu tiên HassIL**: Khi bật `prefer_local_intents` (mặc định trong Home Assistant), các câu lệnh được chuyển hướng tới HassIL trước khi chuyển tới bộ tích hợp này. Khi tắt `prefer_local_intents`, bộ tích hợp mô phỏng lại đúng logic này bằng cách dùng một shortcut gửi trực tiếp câu lệnh gốc tới HassIL. Nếu HassIL xử lý thành công, kết quả được trả về ngay và các bước chuẩn hóa tiếp theo được bỏ qua; nếu HassIL không nhận diện được, quá trình chuẩn hóa bắt đầu.
 
-3. **Tra cứu chỉ mục (Index Lookup)**: Câu lệnh đã chuẩn hóa được tra cứu trong chỉ mục của ngôn ngữ hiện tại, bao gồm:
+3. **Chuẩn hóa văn bản (Text Normalization)**: Chuẩn hóa ký tự theo NFKC, chuyển chữ hoa thành chữ thường theo Unicode, loại bỏ dấu câu và thu gọn khoảng trắng. Quy trình giống nhau được áp dụng cho câu lệnh đầu vào và các câu ứng viên.
+
+4. **Tra cứu chỉ mục (Index Lookup)**: Câu lệnh đã chuẩn hóa được tra cứu trong chỉ mục của ngôn ngữ hiện tại, bao gồm:
    - **Ý định tích hợp sẵn**: Các câu cố định và phần mở rộng mẫu câu có giới hạn từ cấu hình ngôn ngữ của Home Assistant.
    - **Câu lệnh tùy chỉnh**: Định nghĩa trong tệp YAML `custom_sentences/<lang>/`, tập lệnh ý định trong `configuration.yaml` hoặc tự động hóa câu lệnh được tạo từ giao diện.
    - **Thực thể**: Tên và bí danh của các thực thể được cung cấp cho Assist.
    - **Khu vực và tầng**: Tên và bí danh trong sổ đăng ký khu vực, tầng.
 
-4. **Chấm điểm và xếp hạng đa tín hiệu (Multi-Signal Ranking)**: Mỗi ứng viên được đánh giá bằng bốn tín hiệu trước khi tính điểm tổng hợp:
+5. **Chấm điểm và xếp hạng đa tín hiệu (Multi-Signal Ranking)**: Mỗi ứng viên được đánh giá bằng bốn tín hiệu trước khi tính điểm tổng hợp:
    - **Độ tương đồng từ**: Đo mức khớp của từ và thứ tự xuất hiện, hỗ trợ lỗi chính tả hoặc thay đổi vị trí từ.
    - **So khớp mẫu ký tự**: So sánh các nhóm ba ký tự chồng lấn để nhận diện cách viết tương tự.
    - **Độ liên quan từ khóa**: BM25 đánh giá mức độ quan trọng và tính đặc trưng của từng từ trong câu lệnh.
    - **Ngữ cảnh ý định**: Ưu tiên ứng viên có loại ý định, chẳng hạn bật đèn hoặc đặt nhiệt độ, phù hợp với các kết quả hàng đầu.
 
-5. **Kiểm tra độ tin cậy (Confidence Gate)**: Đánh giá ứng viên đứng đầu dựa trên các ngưỡng đã cấu hình:
+6. **Kiểm tra độ tin cậy (Confidence Gate)**: Đánh giá ứng viên đứng đầu dựa trên các ngưỡng đã cấu hình:
    - **Ngưỡng độ tin cậy**: Điểm số cuối cùng của ứng viên phải vượt qua ngưỡng sàn `min_confidence`.
    - **Khoảng cách độ tin cậy**: Thông thường, ứng viên phải dẫn trước đối thủ phù hợp tiếp theo thuộc ý định khác ít nhất `min_margin`. Kết quả khớp từ vựng chính xác có thể bỏ qua khoảng cách này; các chính sách có bằng chứng mạnh khác có thể giảm yêu cầu trước khi đánh giá cạnh tranh giữa các hành động. Nếu không có chính sách phù hợp, các cặp đối nghịch đã biết như bật/tắt, mở/đóng và khóa/mở khóa phải đạt mức chênh lệch đầy đủ. Quyết định và khoảng cách thực tế được hiển thị trong dữ liệu chẩn đoán.
 
-6. **Tiền kiểm, thực thi và khôi phục có giới hạn**: Khi ứng viên vượt qua bộ lọc độ tin cậy, hệ thống tiến hành quy trình xác thực và thực thi theo nhiều giai đoạn:
+7. **Tiền kiểm, thực thi và khôi phục có giới hạn**: Khi ứng viên vượt qua bộ lọc độ tin cậy, hệ thống tiến hành quy trình xác thực và thực thi theo nhiều giai đoạn:
    - **Tiền kiểm nhận diện theo trạng thái thực tế (Live Recognition Preflight)**: Câu lệnh được kiểm tra bằng bộ nhận diện ý định tích hợp sẵn của Home Assistant để xác nhận có thể thực thi. Nếu không hợp lệ, chẳng hạn tham chiếu đến khu vực hoặc thiết bị không tồn tại, ứng viên sẽ bị loại và hệ thống đánh giá danh sách còn lại, tối đa ba câu khác nhau. Nếu không có phương án khả thi, yêu cầu được chuyển sang tác nhân dự phòng.
    - **Thực thi trực tiếp**: Nếu tiền kiểm thành công, câu lệnh được gửi đến tác nhân hội thoại mặc định của Home Assistant (HassIL) để thực thi.
    - **Khôi phục có giới hạn sau thực thi (Bounded Post-Execution Recovery)**: Nếu câu lệnh bị từ chối trước khi bộ xử lý ý định chạy, chẳng hạn trả về `no_intent_match` hoặc `no_valid_targets` do không tìm thấy thực thể, hệ thống có thể khôi phục một lần. Hệ thống loại các lệnh trùng lặp và thử ứng viên phù hợp tiếp theo vẫn đạt ngưỡng tin cậy. Lỗi phát sinh bên trong bộ xử lý ý định không kích hoạt khôi phục và yêu cầu sẽ được chuyển sang dự phòng.
 
-7. **Chuyển tiếp dự phòng (Fallback)**: Nếu không tìm được ứng viên đủ an toàn, không đủ điều kiện khôi phục hoặc quá trình thực thi thất bại, bộ tích hợp chuyển nguyên văn yêu cầu ban đầu tới tác nhân dự phòng đã cấu hình.
+8. **Chuyển tiếp dự phòng (Fallback)**: Khi kích hoạt bỏ qua bằng từ khóa nóng, bộ tích hợp chuyển câu lệnh đã cắt tiền tố tới tác nhân hội thoại dự phòng đã cấu hình. Đối với các trường hợp dự phòng khác (không tìm được ứng viên đủ an toàn, không đủ điều kiện khôi phục hoặc thực thi thất bại), bộ tích hợp sẽ chuyển nguyên văn yêu cầu gốc ban đầu.
 
 ---
 
@@ -321,6 +330,7 @@ Khi câu lệnh bị **chuyển tiếp dự phòng (fallback)**, nguyên nhân c
 
 | Lý do                  | Ý nghĩa                                                                                              |
 | ---------------------- | ---------------------------------------------------------------------------------------------------- |
+| `hotword_matched`      | Câu lệnh khớp với tiền tố từ khóa nóng đã cấu hình và được chuyển thẳng tới tác nhân dự phòng.       |
 | `low_confidence`       | Không có câu lệnh ứng viên nào đạt ngưỡng điểm `min_confidence`.                                     |
 | `low_margin`           | Điểm của ứng viên đứng đầu và ứng viên tiếp theo thuộc ý định khác quá sát nhau (dưới `min_margin`). |
 | `empty_index`          | Chỉ mục câu lệnh của ngôn ngữ hiện tại chưa được xây dựng.                                           |
@@ -340,9 +350,10 @@ Trước khi điều chỉnh ngưỡng, hãy kiểm tra trạng thái hoạt đ�
 
 **Bộ chuẩn hóa luôn chuyển sang dự phòng và không bao giờ so khớp thành công.**
 
-1. Dùng **Diagnostics** để kiểm tra `last_fallback_reason`. `empty_index` cho biết chỉ mục chưa được tạo. Khi khởi động hoặc tải lại, bộ tích hợp xây dựng trước chỉ mục cho các ngôn ngữ đã cấu hình trong Assist pipeline. Nếu `empty_index` vẫn xuất hiện, có thể không có pipeline hoặc ngôn ngữ mặc định phù hợp, hoặc quá trình xây dựng nền chưa hoàn tất. Bạn có thể chạy **Rebuild Index** theo cách thủ công.
-2. Nếu lý do là `low_confidence`, ngưỡng `min_confidence` bạn đặt có thể quá cao. Hãy thử hạ thấp cấu hình này xuống. Bạn nên dùng công cụ **Test Match** để xem điểm số thực tế của các câu lệnh mẫu.
-3. Nếu lý do là `validation_failed`, câu lệnh được chọn đã thất bại khi tiền kiểm, hoặc cả lượt thực thi chính lẫn khôi phục đều không thành công. Bạn hãy sử dụng công cụ **Test Match** để phân tích cách chấm điểm và **Dump Candidates** để kiểm tra các câu lệnh được đăng ký cho ngôn ngữ đó.
+1. Dùng **Diagnostics** để kiểm tra `last_fallback_reason`. Nếu là `hotword_matched`, câu lệnh khớp với tiền tố từ khóa nóng đã cấu hình và đã được chủ động chuyển thẳng tới tác nhân dự phòng (bỏ qua luồng chuẩn hóa hoặc xếp hạng chính).
+2. Nếu là `empty_index`, chỉ mục chưa được tạo. Khi khởi động hoặc tải lại, bộ tích hợp xây dựng trước chỉ mục cho các ngôn ngữ đã cấu hình trong Assist pipeline. Nếu `empty_index` vẫn xuất hiện, có thể không có pipeline hoặc ngôn ngữ mặc định phù hợp, hoặc quá trình xây dựng nền chưa hoàn tất. Bạn có thể chạy **Rebuild Index** theo cách thủ công.
+3. Nếu lý do là `low_confidence`, ngưỡng `min_confidence` bạn đặt có thể quá cao. Hãy thử hạ thấp cấu hình này xuống. Bạn nên dùng công cụ **Test Match** để xem điểm số thực tế của các câu lệnh mẫu.
+4. Nếu lý do là `validation_failed`, câu lệnh được chọn đã thất bại khi tiền kiểm, hoặc cả lượt thực thi chính lẫn khôi phục đều không thành công. Bạn hãy sử dụng công cụ **Test Match** để phân tích cách chấm điểm và **Dump Candidates** để kiểm tra các câu lệnh được đăng ký cho ngôn ngữ đó.
 
 **Mẫu câu tùy chỉnh của tôi không được nhận diện.**
 

--- a/custom_components/assist_canonicalizer/conversation.py
+++ b/custom_components/assist_canonicalizer/conversation.py
@@ -64,6 +64,7 @@ from .utils import (
     normalize_language,
     resolve_entry_hotword_options,
     resolve_entry_thresholds,
+    strip_hotword_prefix,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -275,19 +276,22 @@ class AssistCanonicalizerConversationEntity(
             normalize_language(language) if language else None,
         )
 
-    def _is_hotword_matched(self, user_input: ConversationInput) -> bool:
-        """Return whether user input starts with a configured hotword with high confidence."""
+    def _is_hotword_matched(self, user_input: ConversationInput) -> tuple[bool, str]:
+        """Return whether user input starts with a configured hotword and the stripped text."""
         enable_hotword, hotword, min_confidence = resolve_entry_hotword_options(self._entry)
         if not enable_hotword or not hotword or not user_input.text:
-            return False
+            return False, user_input.text
         language = normalize_language(user_input.language) if user_input.language else None
-        matched, _score, _matched_hw = match_hotword_prefix(
+        matched, _score, matched_hw = match_hotword_prefix(
             user_input.text,
             hotword,
             min_confidence=min_confidence,
             language=language,
         )
-        return matched
+        if matched and matched_hw:
+            stripped = strip_hotword_prefix(user_input.text, matched_hw)
+            return True, stripped
+        return False, user_input.text
 
     async def _async_try_assist_pipeline_shortcut(
         self, user_input: ConversationInput
@@ -393,12 +397,13 @@ class AssistCanonicalizerConversationEntity(
         Every unsuccessful local path still delegates the original text to the
         configured fallback agent.
         """
-        if self._is_hotword_matched(user_input):
+        is_hotword, hotword_stripped_text = self._is_hotword_matched(user_input)
+        if is_hotword:
             self._runtime.update_diagnostics(
                 last_fallback_reason=FallbackReason.HOTWORD_MATCHED,
                 execution_result="hotword_fallback",
             )
-            return await self._delegate_raw_text(user_input)
+            return await self._delegate_text(hotword_stripped_text, user_input, primary=False)
 
         if shortcut_result := await self._async_try_assist_pipeline_shortcut(user_input):
             return shortcut_result

--- a/custom_components/assist_canonicalizer/utils.py
+++ b/custom_components/assist_canonicalizer/utils.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import contextlib
 import logging
 import re
+import string
+import unicodedata
 from collections.abc import Callable, Mapping, Sequence
 from functools import lru_cache
 from math import isclose, isfinite
@@ -25,7 +27,7 @@ from .const import (
     PRESERVED_UNIT_SUFFIXES,
     ConfigKey,
 )
-from .normalization import normalize_text
+from .normalization import normalize_text, tokenize_normalized
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -146,6 +148,64 @@ def resolve_entry_hotword_options(
         min_confidence = DEFAULT_HOTWORD_MIN_CONFIDENCE
     min_confidence = max(0.0, min(min_confidence, 1.0))
     return enable_hotword, hotwords, min_confidence
+
+
+def _strip_leading_punctuation(text: str) -> str:
+    """Strip leading ASCII and Unicode punctuation and whitespace."""
+    idx = 0
+    for char in text:
+        if (
+            char.isspace()
+            or char in string.punctuation
+            or unicodedata.category(char).startswith("P")
+        ):
+            idx += 1
+        else:
+            break
+    return text[idx:]
+
+
+def strip_hotword_prefix(query: str, hotword: str) -> str:
+    """Strip a matched hotword prefix and leading punctuation from the query string.
+
+    Verifies that the query begins with a confirmed hotword match, finds the character
+    boundary after matching the hotword tokens in the raw query, and strips trailing/leading
+    punctuation and whitespace. If stripping would leave an empty string, returns the
+    original query.
+    """
+    if not query or not query.strip():
+        return ""
+    if not hotword or not hotword.strip():
+        return query
+
+    from .ranking import match_hotword_prefix
+
+    matched, _score, _matched_hw = match_hotword_prefix(query, hotword)
+    if not matched:
+        return query
+
+    hw_tokens = tokenize_normalized(normalize_text(hotword))
+    if not hw_tokens:
+        return query
+
+    query_tokens = tokenize_normalized(normalize_text(query))
+    token_len = len(hw_tokens)
+    if len(query_tokens) < token_len:
+        return query
+
+    # Find the character offset in query after matching token_len normalized query tokens.
+    target_tokens = query_tokens[:token_len]
+    pos = 0
+    for end in range(1, len(query) + 1):
+        if tokenize_normalized(normalize_text(query[:end])) == target_tokens:
+            pos = end
+            break
+    else:
+        return query
+
+    remainder = query[pos:]
+    cleaned = _strip_leading_punctuation(remainder).strip()
+    return cleaned or query.strip()
 
 
 @lru_cache(maxsize=128)

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -2428,7 +2428,7 @@ async def test_store_load_failure_delegates_to_fallback_agent() -> None:
 
 @pytest.mark.asyncio
 async def test_hotword_matched_bypasses_ranking_and_delegates_raw_text() -> None:
-    """A matching hotword must bypass ranking and delegate untouched raw text directly."""
+    """A matching hotword must bypass ranking and delegate stripped text directly."""
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {
@@ -2443,16 +2443,45 @@ async def test_hotword_matched_bypasses_ranking_and_delegates_raw_text() -> None
     user_input = MockConversationInput("Jarvis what is the weather tomorrow", "en")
 
     with (
-        patch.object(entity, "_delegate_raw_text", AsyncMock(return_value="raw_delegated")) as raw,
+        patch.object(entity, "_delegate_text", AsyncMock(return_value="delegated")) as delegate,
         patch.object(entity, "_async_rank_request") as rank_mock,
     ):
         res = await entity._async_process_with_runtime(user_input)
 
-    assert res == "raw_delegated"
-    raw.assert_awaited_once_with(user_input)
+    assert res == "delegated"
+    delegate.assert_awaited_once_with("what is the weather tomorrow", user_input, primary=False)
     rank_mock.assert_not_called()
     assert runtime.diagnostics.last_fallback_reason == FallbackReason.HOTWORD_MATCHED
     assert runtime.diagnostics.execution_result == "hotword_fallback"
+
+
+@pytest.mark.asyncio
+async def test_hotword_matched_strips_punctuation_and_preserves_hotword_only() -> None:
+    """A matching hotword strips leading punctuation and retains query when hotword-only."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.options = {
+        ConfigKey.ENABLE_HOTWORD: True,
+        ConfigKey.HOTWORD: "Hey Jarvis",
+    }
+    entry.data = {}
+    runtime = CanonicalizerRuntime()
+    entity = AssistCanonicalizerConversationEntity(entry, runtime)
+    entity.hass = MagicMock()
+
+    # 1. Query with punctuation after hotword
+    user_input1 = MockConversationInput("Hey Jarvis: tell me a joke!", "en")
+    with patch.object(entity, "_delegate_text", AsyncMock(return_value="delegated")) as delegate:
+        res1 = await entity._async_process_with_runtime(user_input1)
+    assert res1 == "delegated"
+    delegate.assert_awaited_once_with("tell me a joke!", user_input1, primary=False)
+
+    # 2. Hotword only input preserves text
+    user_input2 = MockConversationInput("Hey Jarvis", "en")
+    with patch.object(entity, "_delegate_text", AsyncMock(return_value="delegated")) as delegate:
+        res2 = await entity._async_process_with_runtime(user_input2)
+    assert res2 == "delegated"
+    delegate.assert_awaited_once_with("Hey Jarvis", user_input2, primary=False)
 
 
 @pytest.mark.asyncio
@@ -2528,13 +2557,13 @@ async def test_hotword_multiword_and_custom_confidence_matched() -> None:
     user_input = MockConversationInput("Hey Javis turn off everything", "en")
 
     with (
-        patch.object(entity, "_delegate_raw_text", AsyncMock(return_value="raw_delegated")) as raw,
+        patch.object(entity, "_delegate_text", AsyncMock(return_value="delegated")) as delegate,
         patch.object(entity, "_async_rank_request") as rank_mock,
     ):
         res = await entity._async_process_with_runtime(user_input)
 
-    assert res == "raw_delegated"
-    raw.assert_awaited_once_with(user_input)
+    assert res == "delegated"
+    delegate.assert_awaited_once_with("turn off everything", user_input, primary=False)
     rank_mock.assert_not_called()
     assert runtime.diagnostics.last_fallback_reason == FallbackReason.HOTWORD_MATCHED
 
@@ -2586,13 +2615,13 @@ async def test_hotword_list_of_strings_matched() -> None:
     user_input = MockConversationInput("Computer what time is it", "en")
 
     with (
-        patch.object(entity, "_delegate_raw_text", AsyncMock(return_value="raw_delegated")) as raw,
+        patch.object(entity, "_delegate_text", AsyncMock(return_value="delegated")) as delegate,
         patch.object(entity, "_async_rank_request") as rank_mock,
     ):
         res = await entity._async_process_with_runtime(user_input)
 
-    assert res == "raw_delegated"
-    raw.assert_awaited_once_with(user_input)
+    assert res == "delegated"
+    delegate.assert_awaited_once_with("what time is it", user_input, primary=False)
     rank_mock.assert_not_called()
     assert runtime.diagnostics.last_fallback_reason == FallbackReason.HOTWORD_MATCHED
 
@@ -2614,13 +2643,13 @@ async def test_hotword_mixed_invalid_list_filtered_and_matched() -> None:
     user_input = MockConversationInput("Jarvis turn on lights", "en")
 
     with (
-        patch.object(entity, "_delegate_raw_text", AsyncMock(return_value="raw_delegated")) as raw,
+        patch.object(entity, "_delegate_text", AsyncMock(return_value="delegated")) as delegate,
         patch.object(entity, "_async_rank_request") as rank_mock,
     ):
         res = await entity._async_process_with_runtime(user_input)
 
-    assert res == "raw_delegated"
-    raw.assert_awaited_once_with(user_input)
+    assert res == "delegated"
+    delegate.assert_awaited_once_with("turn on lights", user_input, primary=False)
     rank_mock.assert_not_called()
     assert runtime.diagnostics.last_fallback_reason == FallbackReason.HOTWORD_MATCHED
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,11 @@ from typing import Any
 
 import pytest
 
-from custom_components.assist_canonicalizer.utils import is_valid_range_value, parse_float
+from custom_components.assist_canonicalizer.utils import (
+    is_valid_range_value,
+    parse_float,
+    strip_hotword_prefix,
+)
 
 
 @pytest.mark.parametrize(
@@ -68,3 +72,103 @@ def test_is_valid_range_value() -> None:
 
     # Zero step safety check
     assert is_valid_range_value(5.0, 0.0, 0.0, None) is False
+
+
+def test_strip_hotword_prefix() -> None:
+    """Test stripping matched hotword prefixes and leading punctuation from queries."""
+    # 1. Single word hotword with comma
+    assert (
+        strip_hotword_prefix("Jarvis, what is the weather tomorrow?", "Jarvis")
+        == "what is the weather tomorrow?"
+    )
+
+    # 2. Multi-word hotword with colon
+    assert strip_hotword_prefix("Hey Jarvis: tell me a joke!", "Hey Jarvis") == "tell me a joke!"
+
+    # 3. Multi-word with internal and trailing punctuation
+    assert strip_hotword_prefix("Hey, Jarvis, how are you?", "Hey Jarvis") == "how are you?"
+
+    # 4. Single word hotword with dash
+    assert strip_hotword_prefix("Jarvis - what is 2+2?", "Jarvis") == "what is 2+2?"
+
+    # 5. Fuzzy matched typo in query
+    assert strip_hotword_prefix("Jarviss turn off the lights", "Jarvis") == "turn off the lights"
+
+    # 6. Multi-word with diacritics / Vietnamese
+    assert (
+        strip_hotword_prefix("Trợ lý ơi, bật đèn phòng khách giùm tôi", "Tro ly oi")
+        == "bật đèn phòng khách giùm tôi"
+    )
+
+    # 7. Hotword only - must retain original query text to avoid empty prompt to LLM
+    assert strip_hotword_prefix("Jarvis", "Jarvis") == "Jarvis"
+    assert strip_hotword_prefix("Jarvis???", "Jarvis") == "Jarvis???"
+    assert strip_hotword_prefix("Hey Jarvis", "Hey Jarvis") == "Hey Jarvis"
+    assert strip_hotword_prefix("  Hey Jarvis  ", "Hey Jarvis") == "Hey Jarvis"
+
+    # 8. Empty input edge cases
+    assert strip_hotword_prefix("", "Jarvis") == ""
+    assert strip_hotword_prefix("Hello world", "") == "Hello world"
+    assert strip_hotword_prefix("   ", "Jarvis") == ""
+
+    # 9. Numeric hotwords with decimal, time colon, unit suffix, and expressions
+    assert (
+        strip_hotword_prefix("Jarvis 2.0, what is the weather?", "Jarvis 2.0")
+        == "what is the weather?"
+    )
+    assert strip_hotword_prefix("2+2 equals four", "2+2") == "equals four"
+    assert strip_hotword_prefix("Jarvis 12:30 set an alarm", "Jarvis 12:30") == "set an alarm"
+    assert (
+        strip_hotword_prefix("Jarvis 50% increase the brightness", "Jarvis 50%")
+        == "increase the brightness"
+    )
+
+    # 10. Unicode minus sign and compatibility-width characters
+    assert strip_hotword_prefix("Jarvis \u22125 degrees", "Jarvis -5") == "degrees"
+    assert (
+        strip_hotword_prefix("Jarvis \u22125, what is the temperature?", "Jarvis \u22125")
+        == "what is the temperature?"
+    )
+    assert (
+        strip_hotword_prefix("\uff2a\uff41\uff52\uff56\uff49\uff53 turn off the lights", "Jarvis")
+        == "turn off the lights"
+    )
+    assert (
+        strip_hotword_prefix(
+            "\uff2a\uff41\uff52\uff56\uff49\uff53\u3000\u2212\uff15 degrees",
+            "Jarvis -5",
+        )
+        == "degrees"
+    )
+    assert (
+        strip_hotword_prefix(
+            "\uff28\uff45\uff59\u3000\uff2a\uff41\uff52\uff56\uff49\uff53: tell me a joke!",
+            "Hey Jarvis",
+        )
+        == "tell me a joke!"
+    )
+
+    # 11. Full-width punctuation stripping
+    assert (
+        strip_hotword_prefix("Hey Jarvis\uff1a tell me a joke!", "Hey Jarvis") == "tell me a joke!"
+    )
+    assert (
+        strip_hotword_prefix("Hey Jarvis\uff1f what is the time?", "Hey Jarvis")
+        == "what is the time?"
+    )
+    assert strip_hotword_prefix("Hey Jarvis\uff0c turn on lights", "Hey Jarvis") == "turn on lights"
+    assert strip_hotword_prefix("Hey Jarvis\uff01 turn on lights", "Hey Jarvis") == "turn on lights"
+    assert strip_hotword_prefix("Hey Jarvis\u3002 turn on lights", "Hey Jarvis") == "turn on lights"
+    assert strip_hotword_prefix("Jarvis\uff1f\uff1f\uff1f", "Jarvis") == "Jarvis\uff1f\uff1f\uff1f"
+
+    # 12. Unmatched prefixes - must return original query unmodified
+    assert strip_hotword_prefix("Hello world", "Jarvis") == "Hello world"
+    assert (
+        strip_hotword_prefix("Turn on the living room lights", "Jarvis")
+        == "Turn on the living room lights"
+    )
+    assert (
+        strip_hotword_prefix("Japanese restaurants nearby", "Jarvis")
+        == "Japanese restaurants nearby"
+    )
+    assert strip_hotword_prefix("Hey", "Hey Jarvis") == "Hey"


### PR DESCRIPTION
## Summary by Sourcery

Strip matched hot word prefixes before routing complex or ambiguous requests to the configured fallback agent.

New Features:
- Strip matched hot word prefixes and surrounding leading punctuation before forwarding requests to the configured fallback agent.
- Preserve the original input when a hot word is spoken without a meaningful prompt.

Enhancements:
- Record hot word fallback routing distinctly in diagnostics and document the updated processing flow and behavior in English and Vietnamese documentation.

Documentation:
- Update English and Vietnamese documentation to explain prefix stripping, hot word fallback diagnostics, and the interaction with Home Assistant local intent handling.

Tests:
- Add coverage for stripped prompts, punctuation and Unicode handling, fuzzy matches, multi-word and numeric hot words, unmatched prefixes, and hot-word-only input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fuzzy hot-word matching that removes the recognized prefix before sending commands to the configured fallback.
  * Preserved inputs containing only the hot word.
  * Added `hotword_matched` diagnostics to clarify processing and troubleshooting.

* **Documentation**
  * Updated English and Vietnamese guides with hot-word behavior, processing flows, fallback handling, and troubleshooting details.

* **Tests**
  * Expanded coverage for punctuation, multi-word and fuzzy hot words, diacritics, invalid configurations, Unicode input, and empty queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->